### PR TITLE
Fix telematic fetch for multiple vehicles (multi-VIN support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 <p align="center">
   <img src="logo.png" alt="BimmerData Streamline logo" width="240" />
-  <img  width="240" alt="image" src="https://github.com/user-attachments/assets/6cbed4da-7830-417d-b514-ce21d2536c72" />
-  <img  width="240" alt="image" src="https://github.com/user-attachments/assets/f463ee59-0ac7-4e19-adbd-b6aa2d711a9e" />
 </p>
 
 # BimmerData Streamline (BMW CarData for Home Assistant)


### PR DESCRIPTION
### Summary

When multiple BMW vehicles are mapped to the same account, the integration currently only fetches telematic data for a single VIN. This results in entities for other vehicles never getting updated.

This PR changes `_async_perform_telematic_fetch` so that:

- If `vin_override` is provided (service call): only that VIN is fetched.
- Otherwise (scheduled poll): the integration fetches telematic data for **all known VINs**.