### PR TITLE
Obfuscate full VINs in logs as this is identifiable data.

### DIFF
--- a/custom_components/cardata/__init__.py
+++ b/custom_components/cardata/__init__.py
@@ -42,6 +42,7 @@ from .stream import CardataStreamManager
 from .telematics import async_telematic_poll_loop
 from .container import CardataContainerManager
 from .migrations import async_migrate_entity_ids
+from .utils import redact_vin, redact_vins
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -105,17 +106,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     coordinator.names[vin] = vehicle_name
                     _LOGGER.debug(
                         "Pre-populated coordinator.names for VIN %s with: %s (from restored metadata)",
-                        vin,
+                        redact_vin(vin),
                         vehicle_name,
                     )
         
         # Check if metadata is already available from restoration
         has_metadata = bool(coordinator.names)
+        redacted_names = redact_vins(coordinator.names.keys()) if has_metadata else "empty"
         _LOGGER.debug(
             "Metadata restored for entry %s: %s (names: %s)",
             entry.entry_id,
             "yes" if has_metadata else "no",
-            list(coordinator.names.keys()) if has_metadata else "empty",
+            redacted_names,
         )
 
         # Set up quota manager

--- a/custom_components/cardata/container.py
+++ b/custom_components/cardata/container.py
@@ -17,6 +17,7 @@ from .const import (
     HV_BATTERY_DESCRIPTORS,
 )
 from .debug import debug_enabled
+from .utils import redact_vin_in_text
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -311,8 +312,9 @@ class CardataContainerManager:
                 if response.status == 204:
                     return {}
                 text = await response.text()
+                safe_text = redact_vin_in_text(text.strip())
                 raise CardataContainerError(
-                    f"HTTP {response.status}: {text.strip() or 'no response body'}",
+                    f"HTTP {response.status}: {safe_text or 'no response body'}",
                     status=response.status,
                 )
         except aiohttp.ClientError as err:

--- a/custom_components/cardata/coordinator.py
+++ b/custom_components/cardata/coordinator.py
@@ -16,6 +16,7 @@ from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN, DIAGNOSTIC_LOG_INTERVAL
 from .debug import debug_enabled
+from .utils import redact_vin
 from .units import normalize_unit
 
 _LOGGER = logging.getLogger(__name__)
@@ -331,6 +332,7 @@ class CardataCoordinator:
         self, payload: Dict[str, Any], vin: str, data: Dict[str, Any]
     ) -> None:
         """Handle message while holding the lock."""
+        redacted_vin = redact_vin(vin)
         vehicle_state = self.data.setdefault(vin, {})
         new_binary: list[str] = []
         new_sensor: list[str] = []
@@ -338,7 +340,7 @@ class CardataCoordinator:
         self.last_message_at = datetime.now(timezone.utc)
 
         if debug_enabled():
-            _LOGGER.debug("Processing message for VIN %s: %s", vin, list(data.keys()))
+            _LOGGER.debug("Processing message for VIN %s: %s", redacted_vin, list(data.keys()))
 
         tracking = self._soc_tracking.setdefault(vin, SocTracking())
         testing_tracking = self._get_testing_tracking(vin)
@@ -538,7 +540,7 @@ class CardataCoordinator:
             _LOGGER.debug("🔥 Timer firing! Pending items: %d", pending_count)
             if pending_count > 0:
                 for vin, descriptors in self._pending_updates.items():
-                    _LOGGER.debug("   VIN %s: %s", vin[-4:], list(descriptors)[:5])
+                    _LOGGER.debug("   VIN %s: %s", redact_vin(vin), list(descriptors)[:5])
         
         if debug_enabled():
             total_updates = sum(len(descriptors) for descriptors in self._pending_updates.values())

--- a/custom_components/cardata/entity.py
+++ b/custom_components/cardata/entity.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from .const import DOMAIN
 from .coordinator import CardataCoordinator
 from .descriptor_titles import DESCRIPTOR_TITLES
+from .utils import redact_vin_in_text
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -194,7 +195,8 @@ class CardataEntity(RestoreEntity):
         try:
             self._update_name(write_state=True)
         except Exception:
-            _LOGGER.exception("Failed to update name for entity %s", getattr(self, "entity_id", "<unknown>"))
+            entity_id = getattr(self, "entity_id", "<unknown>")
+            _LOGGER.exception("Failed to update name for entity %s", redact_vin_in_text(entity_id))
 
     async def async_will_remove_from_hass(self) -> None:
         if self._name_unsub:

--- a/custom_components/cardata/http_retry.py
+++ b/custom_components/cardata/http_retry.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional, Tuple
 import aiohttp
 
 from .const import HTTP_TIMEOUT
+from .utils import redact_vin_in_text
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -128,6 +129,7 @@ async def async_request_with_retry(
 
             async with session.request(method, url, **request_kwargs) as response:
                 text = await response.text()
+                log_excerpt = redact_vin_in_text(text[:200]) if text else text
                 http_response = HttpResponse(
                     status=response.status,
                     text=text,
@@ -149,7 +151,7 @@ async def async_request_with_retry(
                     _LOGGER.warning(
                         "%s rate limited (429): %s",
                         context,
-                        text[:200],
+                        log_excerpt,
                     )
                     return http_response, None
 
@@ -159,7 +161,7 @@ async def async_request_with_retry(
                         "%s auth error (%d): %s",
                         context,
                         response.status,
-                        text[:200],
+                        log_excerpt,
                     )
                     return http_response, None
 
@@ -169,7 +171,7 @@ async def async_request_with_retry(
                         "%s failed with status %d: %s",
                         context,
                         response.status,
-                        text[:200],
+                        log_excerpt,
                     )
                     return http_response, None
 

--- a/custom_components/cardata/image.py
+++ b/custom_components/cardata/image.py
@@ -15,6 +15,7 @@ from .const import DOMAIN
 from .coordinator import CardataCoordinator
 from .entity import CardataEntity
 from .runtime import CardataRuntimeData
+from .utils import redact_vin
 
 if TYPE_CHECKING:
     pass
@@ -53,7 +54,7 @@ async def async_setup_entry(
         entity = CardataImage(coordinator, vin)
         entities[vin] = entity
         async_add_entities([entity])
-        _LOGGER.debug("Created image entity for VIN: %s", vin)
+        _LOGGER.debug("Created image entity for VIN: %s", redact_vin(vin))
 
     initial_vins = set(coordinator.data.keys()) | set(coordinator.device_metadata.keys())
     for vin in initial_vins:
@@ -109,7 +110,7 @@ class CardataImage(CardataEntity, ImageEntity):
         if self._image_data:
             _LOGGER.debug(
                 "Vehicle image loaded for %s (%d bytes)",
-                self._vin,
+                redact_vin(self._vin),
                 len(self._image_data)
             )
     @property

--- a/custom_components/cardata/metadata.py
+++ b/custom_components/cardata/metadata.py
@@ -24,6 +24,7 @@ from .const import (
 from .http_retry import async_request_with_retry
 from .runtime import async_update_entry_data
 from .quota import CardataQuotaError, QuotaManager
+from .utils import redact_vin, redact_vin_in_text
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -66,6 +67,7 @@ async def async_fetch_and_store_basic_data(
     device_registry = dr.async_get(hass)
 
     for vin in vins:
+        redacted_vin = redact_vin(vin)
         url = f"{API_BASE_URL}{BASIC_DATA_ENDPOINT.format(vin=vin)}"
 
         if quota:
@@ -74,7 +76,7 @@ async def async_fetch_and_store_basic_data(
             except CardataQuotaError as err:
                 _LOGGER.warning(
                     "Basic data request skipped for %s: %s",
-                    vin,
+                    redacted_vin,
                     err,
                 )
                 break
@@ -84,23 +86,24 @@ async def async_fetch_and_store_basic_data(
             "GET",
             url,
             headers=headers,
-            context=f"Basic data request for {vin}",
+            context=f"Basic data request for {redacted_vin}",
         )
 
         if error:
             _LOGGER.warning(
                 "Basic data request errored for %s: %s",
-                vin,
+                redacted_vin,
                 error,
             )
             continue
 
         if response is None or not response.is_success:
+            error_excerpt = redact_vin_in_text(response.text[:200]) if response else ""
             _LOGGER.debug(
                 "Basic data request failed for %s (status=%s): %s",
-                vin,
+                redacted_vin,
                 response.status if response else "no response",
-                response.text[:200] if response else "",
+                error_excerpt,
             )
             continue
 
@@ -109,8 +112,8 @@ async def async_fetch_and_store_basic_data(
         except json.JSONDecodeError:
             _LOGGER.debug(
                 "Basic data payload invalid for %s: %s",
-                vin,
-                response.text[:200],
+                redacted_vin,
+                redact_vin_in_text(response.text[:200]),
             )
             continue
 
@@ -160,6 +163,7 @@ async def async_fetch_and_store_vehicle_images(
     coordinator = runtime.coordinator
 
     for vin in vins:
+        redacted_vin = redact_vin(vin)
         image_path = get_image_path(hass, vin)
         
         # CRITICAL: Check if file already exists
@@ -167,7 +171,7 @@ async def async_fetch_and_store_vehicle_images(
             file_size = image_path.stat().st_size
             _LOGGER.debug(
                 "Vehicle image file already exists for %s (%d bytes) - skipping API call",
-                vin,
+                redacted_vin,
                 file_size
             )
             
@@ -181,14 +185,15 @@ async def async_fetch_and_store_vehicle_images(
                 async_dispatcher_send(hass, coordinator.signal_new_image, vin)
                 _LOGGER.debug(
                     "Loaded vehicle image from file for %s (%d bytes)",
-                    vin,
+                    redacted_vin,
                     len(image_bytes)
                 )
             except Exception as err:
+                safe_err = redact_vin_in_text(str(err))
                 _LOGGER.warning(
                     "Failed to load vehicle image file for %s: %s",
-                    vin,
-                    err
+                    redacted_vin,
+                    safe_err
                 )
             
             continue  # Skip API call - file already exists!
@@ -202,7 +207,7 @@ async def async_fetch_and_store_vehicle_images(
             except CardataQuotaError as err:
                 _LOGGER.debug(
                     "Vehicle image request skipped for %s: %s (will retry on next bootstrap)",
-                    vin,
+                    redacted_vin,
                     err,
                 )
                 break
@@ -211,22 +216,24 @@ async def async_fetch_and_store_vehicle_images(
         try:
             async with session.get(url, headers=headers, timeout=timeout) as response:
                 if response.status == 404:
-                    _LOGGER.debug("No vehicle image available for %s (404)", vin)
+                    _LOGGER.debug("No vehicle image available for %s (404)", redacted_vin)
                     # Create empty marker file to prevent repeated 404 attempts
                     try:
                         image_path.touch()
-                        _LOGGER.debug("Created empty marker file for %s (no image available)", vin)
+                        _LOGGER.debug("Created empty marker file for %s (no image available)", redacted_vin)
                     except Exception as err:
-                        _LOGGER.debug("Failed to create marker file for %s: %s", vin, err)
+                        safe_err = redact_vin_in_text(str(err))
+                        _LOGGER.debug("Failed to create marker file for %s: %s", redacted_vin, safe_err)
                     continue
                 
                 if response.status != 200:
                     text = await response.text()
+                    log_text = redact_vin_in_text(text)
                     _LOGGER.debug(
                         "Vehicle image request failed for %s (status=%s): %s",
-                        vin,
+                        redacted_vin,
                         response.status,
-                        text,
+                        log_text,
                     )
                     # Don't create file - allow retry on next bootstrap
                     continue
@@ -237,7 +244,7 @@ async def async_fetch_and_store_vehicle_images(
                 if not image_data or len(image_data) < 100:
                     _LOGGER.debug(
                         "Vehicle image data too small for %s (%d bytes), likely invalid",
-                        vin,
+                        redacted_vin,
                         len(image_data) if image_data else 0
                     )
                     continue
@@ -246,15 +253,17 @@ async def async_fetch_and_store_vehicle_images(
                 try:
                     # NEW (non-blocking)
                     await hass.async_add_executor_job(image_path.write_bytes, image_data)
+                    safe_image_path = redact_vin_in_text(str(image_path))
                     _LOGGER.info(
                         "Saved vehicle image for %s to %s (%d bytes)",
-                        vin, image_path, len(image_data)
+                        redacted_vin, safe_image_path, len(image_data)
                     )
                 except Exception as err:
+                    safe_err = redact_vin_in_text(str(err))
                     _LOGGER.error(
                         "Failed to save vehicle image file for %s: %s",
-                        vin,
-                        err
+                        redacted_vin,
+                        safe_err
                     )
                     continue
                 
@@ -266,17 +275,19 @@ async def async_fetch_and_store_vehicle_images(
                 async_dispatcher_send(hass, coordinator.signal_new_image, vin)
                 
         except aiohttp.ClientError as err:
+            safe_err = redact_vin_in_text(str(err))
             _LOGGER.debug(
                 "Vehicle image request errored for %s: %s (will retry on next bootstrap)",
-                vin,
-                err,
+                redacted_vin,
+                safe_err,
             )
             continue
         except Exception as err:
+            safe_err = redact_vin_in_text(str(err))
             _LOGGER.warning(
                 "Unexpected error fetching vehicle image for %s: %s",
-                vin,
-                err,
+                redacted_vin,
+                safe_err,
                 exc_info=True
             )
             continue
@@ -303,10 +314,12 @@ async def async_restore_vehicle_images(
     # Load all PNG files from images directory
     for image_file in images_dir.glob("*.png"):
         vin = image_file.stem  # Filename without .png extension
+        redacted_vin = redact_vin(vin)
+        safe_image_file = redact_vin_in_text(str(image_file))
         
         # Skip empty marker files (0 bytes = 404)
         if image_file.stat().st_size == 0:
-            _LOGGER.debug("Skipping empty marker file for %s (no image available)", vin)
+            _LOGGER.debug("Skipping empty marker file for %s (no image available)", redacted_vin)
             continue
         
         try:
@@ -321,16 +334,17 @@ async def async_restore_vehicle_images(
             
             _LOGGER.debug(
                 "Restored vehicle image for %s from %s (%d bytes)",
-                vin,
-                image_file,
+                redacted_vin,
+                safe_image_file,
                 len(image_bytes)
             )
         except Exception as err:
+            safe_err = redact_vin_in_text(str(err))
             _LOGGER.warning(
                 "Failed to restore vehicle image for %s from %s: %s",
-                vin,
-                image_file,
-                err
+                redacted_vin,
+                safe_image_file,
+                safe_err
             )
     
     if restored_count > 0:
@@ -355,13 +369,14 @@ async def async_restore_vehicle_metadata(
     device_registry = dr.async_get(hass)
 
     for vin, payload in stored_metadata.items():
+        redacted_vin = redact_vin(vin)
         if not isinstance(payload, dict):
             continue
 
         try:
             metadata = await coordinator.async_apply_basic_data(vin, payload)
         except Exception:
-            _LOGGER.debug("Failed to restore metadata for %s", vin, exc_info=True)
+            _LOGGER.debug("Failed to restore metadata for %s", redacted_vin, exc_info=True)
             continue
 
         if metadata:

--- a/custom_components/cardata/stream.py
+++ b/custom_components/cardata/stream.py
@@ -16,6 +16,7 @@ from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
 from .debug import debug_enabled
+from .utils import redact_vin_in_text, redact_vin_payload
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -315,7 +316,7 @@ class CardataStreamManager:
             if topic:
                 result = client.subscribe(topic)
                 if debug_enabled():
-                    _LOGGER.debug("Subscribed to %s result=%s", topic, result)
+                    _LOGGER.debug("Subscribed to %s result=%s", redact_vin_in_text(topic), result)
             if self._reauth_notified:
                 self._reauth_notified = False
                 self._awaiting_new_credentials = False
@@ -367,7 +368,11 @@ class CardataStreamManager:
     def _handle_message(self, client: mqtt.Client, userdata, msg: mqtt.MQTTMessage) -> None:
         payload = msg.payload.decode(errors="ignore")
         if debug_enabled():
-            _LOGGER.debug("BMW MQTT message on %s: %s", msg.topic, payload)
+            _LOGGER.debug(
+                "BMW MQTT message on %s: %s",
+                redact_vin_in_text(msg.topic),
+                redact_vin_payload(payload),
+            )
         if not self._message_callback:
             return
         try:

--- a/custom_components/cardata/utils.py
+++ b/custom_components/cardata/utils.py
@@ -1,0 +1,50 @@
+"""Utility helpers for the BMW CarData integration."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable
+
+
+def redact_vin(vin: str | None) -> str:
+    """Return a redacted VIN suitable for logs (first 3 + last 4 characters)."""
+    if not isinstance(vin, str) or not vin:
+        return "<unknown vin>"
+
+    if len(vin) >= 7:
+        return f"{vin[:3]}...{vin[-4:]}"
+
+    # Fallback for very short strings
+    if len(vin) <= 4:
+        return f"...{vin}"
+    return f"{vin[:3]}...{vin[-4:]}"
+
+
+def redact_vins(vins: Iterable[str]) -> list[str]:
+    """Redact an iterable of VINs for logging."""
+    return [redact_vin(v) for v in vins]
+
+
+_VIN_PATTERN = re.compile(r"\b[A-HJ-NPR-Z0-9]{11,17}\b", re.IGNORECASE)
+
+
+def redact_vin_in_text(text: str | None) -> str | None:
+    """Redact VIN-like substrings inside a text value."""
+    if not isinstance(text, str):
+        return text
+    return _VIN_PATTERN.sub(lambda match: redact_vin(match.group(0)), text)
+
+
+def redact_vin_payload(payload: Any) -> Any:
+    """Return a copy of payload with VIN-like strings redacted."""
+    if isinstance(payload, dict):
+        return {key: redact_vin_payload(value) for key, value in payload.items()}
+    if isinstance(payload, list):
+        return [redact_vin_payload(item) for item in payload]
+    if isinstance(payload, tuple):
+        return tuple(redact_vin_payload(item) for item in payload)
+    if isinstance(payload, set):
+        return {redact_vin_payload(item) for item in payload}
+    if isinstance(payload, str):
+        return redact_vin_in_text(payload)
+    return payload


### PR DESCRIPTION
Obfuscate full VINs in logs as this is identifiable data. Keep the first 3 letters to determine if it's BMW or Mini and the last 4 numbers. The collision probability on a single HA instance should be extremely low.

BMW (EU WMIs only)
WBA — BMW AG — Passenger Car 
WBS — BMW M GmbH — Passenger Car 
WBY — BMW AG — Passenger Car (commonly used on BMW i / electrified lines) 
WBX — BMW AG — MPV (BMW “SAV/SUV/crossover” VIN category) 
WB5 — BMW AG — MPV (seen on newer BMW i MPV/SUV-type vehicles) 

MINI (EU WMIs only)
WMW — BMW AG — Passenger Car (MINI)

Maybe 2 letters only was sufficient as it's W for Germany and B for BMW and M for Mini at least for EU models, which are the only ones cardata supports ATM. But be careful in case in the future they support US/mexico plants.