### PR TITLE
Fix false "clock went backwards" warnings from out-of-order BMW timestamps

### DIFF
--- a/custom_components/cardata/soc_tracking.py
+++ b/custom_components/cardata/soc_tracking.py
@@ -487,8 +487,14 @@ class SocTracking:
 
             # Advance the running estimate to the moment this power sample was taken
             # so the previous charging rate is accounted for before we swap in the
-            # new value.
-            self.estimate(target_time)
+            # new value. Only advance if target_time is not before last_estimate_time
+            # (descriptors can arrive out-of-order with different timestamps).
+            if self.last_estimate_time is None:
+                self.estimate(target_time)
+            else:
+                normalized_estimate_time = self._normalize_timestamp(self.last_estimate_time)
+                if normalized_estimate_time is None or target_time >= normalized_estimate_time:
+                    self.estimate(target_time)
 
             # Compute all new values FIRST before modifying any state.
             # This ensures atomic-ish updates: if any computation fails, state unchanged.


### PR DESCRIPTION
BMW sends descriptors with different timestamps (e.g., charging.level at 10:23:25 vs acVoltage at 10:14:19). When update_power() received a descriptor with an older timestamp, it would try to call estimate() with that older time, triggering a spurious "clock went backwards" warning.

Fixed by only advancing the estimate forward in time. When descriptors arrive out-of-order, we now just update the power values without trying to retroactively adjust the estimate timeline.