### PR TITLE
Fix VIN deduplication persistence across restarts

### DIFF
--- a/custom_components/cardata/const.py
+++ b/custom_components/cardata/const.py
@@ -153,3 +153,6 @@ AC_SESSION_FINALIZE_MINUTES = 15.0
 # Storage key and version for learned efficiency data
 SOC_LEARNING_STORAGE_KEY = "cardata.soc_learning"
 SOC_LEARNING_STORAGE_VERSION = 1
+
+# Key for storing deduplicated allowed VINs in entry data
+ALLOWED_VINS_KEY = "allowed_vins"


### PR DESCRIPTION
Store deduplicated allowed VINs in entry data so they persist across Home Assistant restarts. Previously, both config entries would restore VINs from metadata before deduplication ran, causing duplicate entities.

Changes:
- Add ALLOWED_VINS_KEY constant for storing VINs in entry data
- Store allowed VINs after bootstrap deduplication completes
- Restore VINs from entry data instead of deriving from metadata
- Add cleanup function to remove duplicate devices for deduplicated VINs
- Check for key existence (not emptiness) to avoid unnecessary bootstrap runs

Migration is automatic: existing installs without stored allowed_vins will trigger bootstrap on first restart, which deduplicates and persists the correct VIN assignments.