### PR TITLE
Fix BMW CarData API quota from 500 to 50 calls/day and add MQTT-based conditional polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,12 +246,26 @@ Home Assistant's Developer Tools expose helper services for manual API checks:
 - `cardata.fetch_basic_data` calls `GET /customers/vehicles/{vin}/basicData` to retrieve static metadata (model name, series, etc.) for the specified VIN.
 - `migrations` call for proper renaming the sensors from old installations
 
+## API Quota and MQTT Streaming
+
+BMW imposes a **50 calls/day** limit on the CarData API. This integration is designed to minimize API usage:
+
+- **MQTT Stream (primary)**: The MQTT stream is unlimited and provides real-time updates. This is the primary data source.
+- **API Polling (fallback)**: The integration only polls the API when MQTT has been inactive for 1+ hour. This dramatically reduces API usage.
+- **Multi-VIN setups**: All vehicles share the same 50 call/day quota. The conditional polling ensures you stay within limits even with multiple cars.
+
+### Quota Warnings
+
+- At 70% usage (28 calls): Warning logged
+- At 90% usage (36 calls): Critical warning logged
+- At 100% usage (40 calls): API calls blocked until quota resets at midnight UTC
+
 ## Requirements
 
 - BMW CarData account with streaming access (CarData API + CarData Streaming subscribed in the portal).
 - Client ID created in the BMW portal (see "BMW Portal Setup").
 - Home Assistant 2025.3+.
-- Familiarity with BMW’s CarData documentation: https://bmw-cardata.bmwgroup.com/customer/public/api-documentation/Id-Introduction
+- Familiarity with BMW's CarData documentation: https://bmw-cardata.bmwgroup.com/customer/public/api-documentation/Id-Introduction
 
 ## Known Limitations
 

--- a/custom_components/cardata/bootstrap.py
+++ b/custom_components/cardata/bootstrap.py
@@ -317,7 +317,7 @@ async def async_fetch_primary_vins(
         reason = f"rate limited (429): {error_excerpt}"
         _LOGGER.error(
             "BMW API rate limit exceeded! Bootstrap mapping request blocked for entry %s. "
-            "BMW's daily quota (typically 500 calls/day) has been reached. "
+            "BMW's daily quota (typically 50 calls/day) has been reached. "
             "The limit resets at midnight UTC. Please wait and try again later. "
             "Error details: %s",
             entry_id,
@@ -440,7 +440,7 @@ async def async_seed_telematic_data(
             error_excerpt = redact_vin_in_text(response.text[:200])
             _LOGGER.error(
                 "BMW API rate limit exceeded! Bootstrap telematic request blocked for %s. "
-                "BMW's daily quota (typically 500 calls/day) has been reached. "
+                "BMW's daily quota (typically 50 calls/day) has been reached. "
                 "The limit resets at midnight UTC. Skipping remaining vehicles. "
                 "Error details: %s",
                 redacted_vin,

--- a/custom_components/cardata/const.py
+++ b/custom_components/cardata/const.py
@@ -69,14 +69,16 @@ DIAGNOSTIC_LOG_INTERVAL = 30  # How often we print stream logs in seconds
 BOOTSTRAP_COMPLETE = "bootstrap_complete"
 REQUEST_LOG = "request_log"
 REQUEST_LOG_VERSION = 1
-# API Quota - 80% of BMW's ~500/day limit (leaves safety margin)
-REQUEST_LIMIT = 400
+# API Quota - 80% of BMW's 50/day limit (leaves safety margin)
+REQUEST_LIMIT = 40
 # How long API Quota is reserved after API Call in seconds
 REQUEST_WINDOW_SECONDS = 24 * 60 * 60
 
 # Quota thresholds for warnings (percentages of REQUEST_LIMIT)
-QUOTA_WARNING_THRESHOLD = 280  # Warn at 70% of REQUEST_LIMIT
-QUOTA_CRITICAL_THRESHOLD = 360  # Critical at 90% of REQUEST_LIMIT
+QUOTA_WARNING_THRESHOLD = 28  # Warn at 70% of REQUEST_LIMIT
+QUOTA_CRITICAL_THRESHOLD = 36  # Critical at 90% of REQUEST_LIMIT
+# How long MQTT must be inactive before API polling triggers (seconds)
+MQTT_INACTIVITY_THRESHOLD = 60 * 60  # 1 hour
 # How often to call the Telematic API in seconds
 TELEMATIC_POLL_INTERVAL = 40 * 60
 HTTP_TIMEOUT = 30  # Timeout for HTTP API requests in seconds

--- a/custom_components/cardata/ratelimit.py
+++ b/custom_components/cardata/ratelimit.py
@@ -77,7 +77,7 @@ class RateLimitTracker:
         _LOGGER.error(
             "BMW API rate limit hit (429) on %s! This is attempt #%d. "
             "Cooling down for %.1f hours until %s (using %s). "
-            "BMW's daily quota is typically 500 calls/day and resets at midnight UTC. "
+            "BMW's daily quota is typically 50 calls/day and resets at midnight UTC. "
             "The integration will pause API calls during cooldown.",
             endpoint,
             self._429_count,


### PR DESCRIPTION
Problem:
The integration incorrectly assumed BMW's API quota was 500 calls/day when the actual limit is 50 calls/day. This caused users to hit rate limits daily, especially with multiple VINs, and displayed misleading error messages.

Root cause verified via:
- ioBroker BMW adapter documentation confirms "50 API calls per 24-hour limit"
- BMW CarData portal documentation
- User reports of 429 errors with far fewer than 500 calls

Changes:

1. Quota constants updated in const.py:
   - REQUEST_LIMIT: 400 -> 40 (80% safety margin of real 50/day limit)
   - QUOTA_WARNING_THRESHOLD: 280 -> 28 (warns at 70% usage)
   - QUOTA_CRITICAL_THRESHOLD: 360 -> 36 (critical at 90% usage)
   - Added MQTT_INACTIVITY_THRESHOLD = 3600 seconds (1 hour)

2. Error messages corrected to show "50 calls/day" instead of "500 calls/day":
   - ratelimit.py: RateLimitTracker.record_429() error message
   - bootstrap.py: async_fetch_primary_vins() rate limit error
   - bootstrap.py: async_seed_telematic_data() rate limit error

3. Conditional polling implemented in telematics.py:
   - API polling now only triggers when MQTT stream has been inactive for 1+ hour
   - If coordinator.last_message_at is within the threshold, polling is skipped
   - This dramatically reduces API usage since MQTT streaming is unlimited
   - Fallback behavior preserved: if MQTT never connects or dies for >1 hour, API polling resumes normally