### PR TITLE
Fix lock deadlocks in MQTT reconnect and token refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Home Assistant's Developer Tools expose helper services for manual API checks:
 
 BMW imposes a **50 calls/day** limit on the CarData API. This integration is designed to minimize API usage through event-driven polling:
 
-- **MQTT Stream (real-time)**: The MQTT stream is unlimited and provides real-time updates for events like door locks, motion state, charging power, etc. GPS coordinates are paired using BMW payload timestamps (same GPS fix detection) with an arrival-time fallback, so location updates work even when latitude and longitude arrive in separate MQTT messages.
+- **MQTT Stream (real-time)**: The MQTT stream is unlimited and provides real-time updates for events like door locks, motion state, charging power, etc. GPS coordinates are paired using BMW payload timestamps (same GPS fix detection) with an arrival-time fallback, so location updates work even when latitude and longitude arrive in separate MQTT messages. Token refresh during MQTT reconnection is lock-free to avoid blocking the connection.
 - **Trip-end polling**: When a vehicle stops moving (trip ends), the integration triggers an immediate API poll to capture post-trip battery state.
 - **Charge-end polling**: When charging completes or stops, the integration triggers an immediate API poll to get the actual BMW SOC for learning calibration of the predicted SOC sensor.
 - **Fallback polling**: The integration polls every 12 hours as a fallback in case MQTT stream fails or after Home Assistant restarts.

--- a/custom_components/cardata/stream.py
+++ b/custom_components/cardata/stream.py
@@ -915,6 +915,22 @@ class CardataStreamManager:
             self._awaiting_new_credentials = False
         await self._notify_recovered()
 
+    def set_credentials(
+        self,
+        *,
+        gcid: str | None = None,
+        id_token: str | None = None,
+    ) -> None:
+        """Update credentials in memory without reconnecting or acquiring locks.
+
+        Use this when the caller will handle reconnection separately
+        (e.g. _async_reconnect already holds _connect_lock and restarts MQTT itself).
+        """
+        if gcid and gcid != self._gcid:
+            self._gcid = gcid
+        if id_token and id_token != self._password:
+            self._password = id_token
+
     async def async_update_credentials(
         self,
         *,


### PR DESCRIPTION
Token refresh from _async_reconnect called async_update_credentials which tried to acquire _connect_lock already held by the caller, causing a 60-second hang on every reconnect with token refresh.

The refresh_loop and _async_reconnect could also deadlock each other by acquiring _token_refresh_lock and _connect_lock in opposite order (AB-BA pattern), causing 30-60 second hangs.

Fix: add set_credentials() that updates MQTT credentials in memory without locks or reconnection. _do_token_refresh now uses this instead of async_update_credentials. Callers handle reconnection themselves. handle_stream_error explicitly reconnects after successful unauthorized token refresh.