### PR TITLE
Add config flow translations for 6 European languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,20 @@ BMW imposes a **50 calls/day** limit on the CarData API. This integration does n
 - TLS 1.3 capable SSL library: OpenSSL 1.1.1+, LibreSSL 3.2.0+, or equivalent (BMW's MQTT server requires TLS 1.3).
 - Familiarity with BMW's CarData documentation: https://bmw-cardata.bmwgroup.com/customer/public/api-documentation/Id-Introduction
 
+## Translations
+
+The setup wizard, error messages, and options menu are translated into the following languages:
+
+- English (en)
+- German (de)
+- French (fr)
+- Italian (it)
+- Dutch (nl)
+- Spanish (es)
+- Portuguese (pt)
+
+Home Assistant automatically selects the translation matching your configured language. Entity names are not translated as they use BMW descriptor names with values and units.
+
 ## Known Limitations
 
 - Only one BMW stream per GCID: make sure no other clients are connected simultaneously.

--- a/custom_components/cardata/translations/de.json
+++ b/custom_components/cardata/translations/de.json
@@ -1,0 +1,57 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "BMW Cardata",
+        "description": "Geben Sie Ihre BMW CarData Client-ID ein."
+      },
+      "authorize": {
+        "title": "BMW CarData autorisieren",
+        "description": "Öffnen Sie {verification_url} und geben Sie den Benutzercode {user_code} ein, falls danach gefragt wird. Sobald Sie das Gerät genehmigt haben, klicken Sie auf Absenden. Falls die Genehmigung bereits abgeschlossen wurde, klicken Sie erneut auf Absenden, um fortzufahren."
+      },
+      "blocked": {
+        "title": "Bootstrap aufgrund des API-Ratenlimits deaktiviert",
+        "description": "Die Integration hat zuvor das tägliche BMW-API-Ratenlimit erreicht und der automatische Bootstrap (Container-Erstellung und Mapping) wurde für {entry_title} vorübergehend bis {until} deaktiviert. Sie können entweder bis zu diesem Zeitpunkt warten und es erneut versuchen, oder das Flag unten löschen, um es sofort erneut zu versuchen (möglicherweise wird das Ratenlimit erneut erreicht)."
+      },
+      "cleared": {
+        "title": "Bootstrap-Wiederholung geplant",
+        "description": "Sie haben das temporäre Deaktivierungs-Flag für {entry_title} gelöscht. Die Integration wird den Bootstrap erneut versuchen. Wenn das BMW-API-Ratenlimit erneut erreicht wird, wird die Integration den Bootstrap bis zur Rücksetzzeit wieder deaktivieren. Alternativ können Sie den Entwicklerdienst `cardata.clean_hv_containers` verwenden, um alte Container aufzulisten/zu löschen (achten Sie auf API-Ratenlimits)."
+      },
+      "blocked_fallback": {
+        "description": "Der automatische Bootstrap ist bis {until} deaktiviert. Löschen Sie das Flag, um es jetzt erneut zu versuchen, oder brechen Sie ab und versuchen Sie es nach dem Zurücksetzen erneut."
+      }
+    },
+    "error": {
+      "authorization_failed": "Die BMW-Autorisierung wurde nicht abgeschlossen. Dies bedeutet normalerweise, dass Sie auf \"Ablehnen\" geklickt, die Seite vor der Genehmigung geschlossen oder die Anfrage eine Zeitüberschreitung hatte. Fehlerdetails: {error}. Bitte entfernen Sie die Integration und versuchen Sie, sie erneut hinzuzufügen. Stellen Sie sicher, dass Sie auf \"Genehmigen\" klicken, wenn BMW um Erlaubnis bittet.",
+      "device_code_failed": "BMW hat die Geräteautorisierungsanfrage abgelehnt ({error}). Überprüfen Sie, ob die Client-ID gültig ist, und versuchen Sie es erneut."
+    },
+    "abort": {
+      "auth_failed": "Die BMW-Autorisierungsantwort war unvollständig (fehlende Token). Bitte versuchen Sie es erneut.",
+      "reauth_device_code_failed": "BMW hat die Geräteautorisierungsanfrage abgelehnt ({error}). Aktualisieren Sie die Client-ID unter Konfigurieren > Geräteautorisierung erneut starten, oder entfernen Sie die Integration und fügen Sie sie erneut hinzu.",
+      "reauth_missing_client_id": "Die Client-ID fehlt für diesen Integrationseintrag. Entfernen Sie die Integration und fügen Sie sie erneut hinzu, um sich erneut zu autorisieren.",
+      "reauth_failed": "Die erneute Autorisierung konnte nicht gestartet werden. Versuchen Sie es erneut über die Integrationsoptionen."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Manuelle Aktionen",
+        "description": "Wählen Sie die Aktion aus, die Sie ausführen möchten. Token aktualisieren versucht nur, die Token ohne erneute Autorisierung zu erneuern. Wir empfehlen, HA danach neu zu starten, wenn Sie Probleme haben."
+      }
+    },
+    "error": {
+      "refresh_failed": "Token-Aktualisierung fehlgeschlagen: {error}",
+      "runtime_missing": "Die Integrationslaufzeit ist nicht bereit. Versuchen Sie es erneut, nachdem die Einrichtung abgeschlossen ist.",
+      "no_vins": "Es sind noch keine VINs bekannt. Warten Sie, bis der Stream ein Fahrzeug erkennt, oder lösen Sie es einmal manuell aus.",
+      "invalid_int": "Geben Sie eine positive Ganzzahl ein",
+      "invalid_client_id": "Geben Sie die BMW CarData Client-ID ein."
+    },
+    "abort": {
+      "auth_failed": "Die BMW-Autorisierungsantwort war unvollständig (fehlende Token). Bitte versuchen Sie es erneut.",
+      "reauth_started": "Autorisierung neu gestartet. Schließen Sie den neuen Anmeldevorgang über die Benachrichtigung ab.",
+      "reauth_device_code_failed": "BMW hat die Geräteautorisierungsanfrage abgelehnt ({error}). Aktualisieren Sie die Client-ID in den Integrationsoptionen und versuchen Sie es erneut.",
+      "reauth_missing_client_id": "Die Client-ID fehlt für diesen Integrationseintrag. Entfernen Sie die Integration und fügen Sie sie erneut hinzu, um sich erneut zu autorisieren.",
+      "reauth_failed": "Die erneute Autorisierung konnte nicht gestartet werden. Versuchen Sie es erneut über die Integrationsoptionen."
+    }
+  }
+}

--- a/custom_components/cardata/translations/es.json
+++ b/custom_components/cardata/translations/es.json
@@ -1,0 +1,57 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "BMW Cardata",
+        "description": "Introduce tu ID de cliente BMW CarData."
+      },
+      "authorize": {
+        "title": "Autorizar BMW CarData",
+        "description": "Abre {verification_url} e introduce el código de usuario {user_code} si se solicita. Una vez que hayas aprobado el dispositivo, haz clic en Enviar. Si la aprobación ya se completó, haz clic en Enviar de nuevo para continuar."
+      },
+      "blocked": {
+        "title": "Bootstrap deshabilitado por límite de velocidad de la API",
+        "description": "La integración alcanzó previamente el límite diario de la API de BMW y el bootstrap automático (creación de contenedores y mapeo) ha sido temporalmente deshabilitado para {entry_title} hasta {until}. Puedes esperar hasta ese momento y volver a intentarlo, o borrar la marca a continuación para reintentar inmediatamente (podrías alcanzar el límite de velocidad de nuevo)."
+      },
+      "cleared": {
+        "title": "Reintento de bootstrap programado",
+        "description": "Has borrado la marca de deshabilitación temporal para {entry_title}. La integración intentará el bootstrap de nuevo. Si se alcanza nuevamente el límite de la API de BMW, la integración deshabilitará el bootstrap hasta la hora de restablecimiento. Alternativamente, usa el servicio de desarrollador `cardata.clean_hv_containers` para listar/eliminar contenedores antiguos (ten en cuenta los límites de la API)."
+      },
+      "blocked_fallback": {
+        "description": "El bootstrap automático está deshabilitado hasta {until}. Borra la marca para reintentar ahora, o cancela e inténtalo de nuevo después del restablecimiento."
+      }
+    },
+    "error": {
+      "authorization_failed": "La autorización de BMW no se completó. Esto generalmente significa que hiciste clic en \"Denegar\", cerraste la página antes de aprobar, o la solicitud expiró. Detalles del error: {error}. Por favor, elimina la integración e intenta añadirla de nuevo, asegurándote de hacer clic en \"Aprobar\" cuando BMW solicite permiso.",
+      "device_code_failed": "BMW rechazó la solicitud de autorización del dispositivo ({error}). Verifica que el ID de cliente sea válido e inténtalo de nuevo."
+    },
+    "abort": {
+      "auth_failed": "La respuesta de autorización de BMW estaba incompleta (faltan tokens). Inténtalo de nuevo.",
+      "reauth_device_code_failed": "BMW rechazó la solicitud de autorización del dispositivo ({error}). Actualiza el ID de cliente en Configurar > Reiniciar autorización del dispositivo, o elimina y vuelve a añadir la integración.",
+      "reauth_missing_client_id": "Falta el ID de cliente para esta entrada de integración. Elimina y vuelve a añadir la integración para autorizarte de nuevo.",
+      "reauth_failed": "No se pudo iniciar la reautorización. Inténtalo de nuevo desde las opciones de la integración."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Acciones manuales",
+        "description": "Selecciona la acción que deseas ejecutar. Actualizar tokens solo intenta renovar los tokens sin reautorización. Te sugerimos reiniciar HA después si tienes problemas."
+      }
+    },
+    "error": {
+      "refresh_failed": "Error al actualizar tokens: {error}",
+      "runtime_missing": "El entorno de ejecución de la integración no está listo. Inténtalo de nuevo después de que se complete la configuración.",
+      "no_vins": "Aún no se conocen VINs. Espera a que el stream descubra un vehículo o actívalo manualmente una vez.",
+      "invalid_int": "Introduce un número entero positivo",
+      "invalid_client_id": "Introduce el ID de cliente BMW CarData."
+    },
+    "abort": {
+      "auth_failed": "La respuesta de autorización de BMW estaba incompleta (faltan tokens). Inténtalo de nuevo.",
+      "reauth_started": "Autorización reiniciada. Completa el nuevo flujo de inicio de sesión desde la notificación.",
+      "reauth_device_code_failed": "BMW rechazó la solicitud de autorización del dispositivo ({error}). Actualiza el ID de cliente en las opciones de la integración e inténtalo de nuevo.",
+      "reauth_missing_client_id": "Falta el ID de cliente para esta entrada de integración. Elimina y vuelve a añadir la integración para autorizarte de nuevo.",
+      "reauth_failed": "No se pudo iniciar la reautorización. Inténtalo de nuevo desde las opciones de la integración."
+    }
+  }
+}

--- a/custom_components/cardata/translations/fr.json
+++ b/custom_components/cardata/translations/fr.json
@@ -1,0 +1,57 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "BMW Cardata",
+        "description": "Entrez votre identifiant client BMW CarData."
+      },
+      "authorize": {
+        "title": "Autoriser BMW CarData",
+        "description": "Ouvrez {verification_url} et entrez le code utilisateur {user_code} si demandé. Une fois que vous avez approuvé l'appareil, cliquez sur Soumettre. Si l'approbation est déjà terminée, cliquez à nouveau sur Soumettre pour continuer."
+      },
+      "blocked": {
+        "title": "Bootstrap désactivé en raison de la limite de débit API",
+        "description": "L'intégration a précédemment atteint la limite de débit quotidienne de l'API BMW et le bootstrap automatique (création de conteneur et mappage) a été temporairement désactivé pour {entry_title} jusqu'à {until}. Vous pouvez soit attendre ce moment et réessayer, soit effacer le flag ci-dessous pour réessayer immédiatement (vous pourriez atteindre à nouveau la limite de débit)."
+      },
+      "cleared": {
+        "title": "Nouvelle tentative de bootstrap planifiée",
+        "description": "Vous avez effacé le flag de désactivation temporaire pour {entry_title}. L'intégration tentera à nouveau le bootstrap. Si la limite de débit de l'API BMW est à nouveau atteinte, l'intégration désactivera le bootstrap jusqu'à l'heure de réinitialisation. Alternativement, utilisez le service développeur `cardata.clean_hv_containers` pour lister/supprimer les anciens conteneurs (attention aux limites de débit API)."
+      },
+      "blocked_fallback": {
+        "description": "Le bootstrap automatique est désactivé jusqu'à {until}. Effacez le flag pour réessayer maintenant, ou annulez et réessayez après la réinitialisation."
+      }
+    },
+    "error": {
+      "authorization_failed": "L'autorisation BMW n'a pas été complétée. Cela signifie généralement que vous avez cliqué sur « Refuser », fermé la page avant d'approuver, ou que la demande a expiré. Détails de l'erreur : {error}. Veuillez supprimer l'intégration et essayer de l'ajouter à nouveau, en vous assurant de cliquer sur « Approuver » lorsque BMW demande la permission.",
+      "device_code_failed": "BMW a rejeté la demande d'autorisation de l'appareil ({error}). Vérifiez que l'identifiant client est valide et réessayez."
+    },
+    "abort": {
+      "auth_failed": "La réponse d'autorisation BMW était incomplète (jetons manquants). Veuillez réessayer.",
+      "reauth_device_code_failed": "BMW a rejeté la demande d'autorisation de l'appareil ({error}). Mettez à jour l'identifiant client sous Configurer > Relancer l'autorisation de l'appareil, ou supprimez et ajoutez à nouveau l'intégration.",
+      "reauth_missing_client_id": "L'identifiant client est manquant pour cette entrée d'intégration. Supprimez et ajoutez à nouveau l'intégration pour vous autoriser de nouveau.",
+      "reauth_failed": "La réautorisation n'a pas pu être lancée. Réessayez depuis les options de l'intégration."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Actions manuelles",
+        "description": "Sélectionnez l'action que vous souhaitez exécuter. Rafraîchir les jetons tente simplement de renouveler les jetons sans réautorisation. Nous vous suggérons de redémarrer HA après cela si vous rencontrez des problèmes."
+      }
+    },
+    "error": {
+      "refresh_failed": "Échec du rafraîchissement des jetons : {error}",
+      "runtime_missing": "L'environnement d'exécution de l'intégration n'est pas prêt. Réessayez une fois la configuration terminée.",
+      "no_vins": "Aucun VIN n'est encore connu. Attendez que le flux découvre un véhicule ou déclenchez-le une fois manuellement.",
+      "invalid_int": "Entrez un nombre entier positif",
+      "invalid_client_id": "Entrez l'identifiant client BMW CarData."
+    },
+    "abort": {
+      "auth_failed": "La réponse d'autorisation BMW était incomplète (jetons manquants). Veuillez réessayer.",
+      "reauth_started": "Autorisation redémarrée. Complétez le nouveau flux de connexion depuis la notification.",
+      "reauth_device_code_failed": "BMW a rejeté la demande d'autorisation de l'appareil ({error}). Mettez à jour l'identifiant client dans les options de l'intégration et réessayez.",
+      "reauth_missing_client_id": "L'identifiant client est manquant pour cette entrée d'intégration. Supprimez et ajoutez à nouveau l'intégration pour vous autoriser de nouveau.",
+      "reauth_failed": "La réautorisation n'a pas pu être lancée. Réessayez depuis les options de l'intégration."
+    }
+  }
+}

--- a/custom_components/cardata/translations/it.json
+++ b/custom_components/cardata/translations/it.json
@@ -1,0 +1,57 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "BMW Cardata",
+        "description": "Inserisci il tuo ID client BMW CarData."
+      },
+      "authorize": {
+        "title": "Autorizza BMW CarData",
+        "description": "Apri {verification_url} e inserisci il codice utente {user_code} se richiesto. Una volta approvato il dispositivo, fai clic su Invia. Se l'approvazione è già stata completata, fai nuovamente clic su Invia per continuare."
+      },
+      "blocked": {
+        "title": "Bootstrap disabilitato a causa del limite di velocità API",
+        "description": "L'integrazione ha precedentemente raggiunto il limite giornaliero dell'API BMW e il bootstrap automatico (creazione container e mappatura) è stato temporaneamente disabilitato per {entry_title} fino a {until}. Puoi attendere fino a quel momento e riprovare, oppure cancellare il flag qui sotto per riprovare immediatamente (potresti raggiungere nuovamente il limite di velocità)."
+      },
+      "cleared": {
+        "title": "Nuovo tentativo di bootstrap pianificato",
+        "description": "Hai cancellato il flag di disabilitazione temporanea per {entry_title}. L'integrazione tenterà nuovamente il bootstrap. Se il limite dell'API BMW viene raggiunto di nuovo, l'integrazione disabiliterà il bootstrap fino all'orario di ripristino. In alternativa, usa il servizio sviluppatore `cardata.clean_hv_containers` per elencare/eliminare vecchi container (fai attenzione ai limiti dell'API)."
+      },
+      "blocked_fallback": {
+        "description": "Il bootstrap automatico è disabilitato fino a {until}. Cancella il flag per riprovare ora, oppure annulla e riprova dopo il ripristino."
+      }
+    },
+    "error": {
+      "authorization_failed": "L'autorizzazione BMW non è stata completata. Questo di solito significa che hai cliccato su \"Rifiuta\", hai chiuso la pagina prima di approvare o la richiesta è scaduta. Dettagli dell'errore: {error}. Rimuovi l'integrazione e prova ad aggiungerla di nuovo, assicurandoti di cliccare su \"Approva\" quando BMW chiede il permesso.",
+      "device_code_failed": "BMW ha rifiutato la richiesta di autorizzazione del dispositivo ({error}). Verifica che l'ID client sia valido e riprova."
+    },
+    "abort": {
+      "auth_failed": "La risposta di autorizzazione BMW era incompleta (token mancanti). Riprova.",
+      "reauth_device_code_failed": "BMW ha rifiutato la richiesta di autorizzazione del dispositivo ({error}). Aggiorna l'ID client in Configura > Riavvia autorizzazione dispositivo, oppure rimuovi e aggiungi nuovamente l'integrazione.",
+      "reauth_missing_client_id": "L'ID client manca per questa voce di integrazione. Rimuovi e aggiungi nuovamente l'integrazione per autorizzarti di nuovo.",
+      "reauth_failed": "La riautorizzazione non è stata avviata. Riprova dalle opzioni dell'integrazione."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Azioni manuali",
+        "description": "Seleziona l'azione che vuoi eseguire. Aggiorna token tenta semplicemente di rinnovare i token senza riautorizzazione. Ti consigliamo di riavviare HA dopo se riscontri problemi."
+      }
+    },
+    "error": {
+      "refresh_failed": "Aggiornamento token fallito: {error}",
+      "runtime_missing": "L'ambiente di esecuzione dell'integrazione non è pronto. Riprova dopo il completamento della configurazione.",
+      "no_vins": "Nessun VIN è ancora noto. Attendi che lo stream rilevi un veicolo o attivalo manualmente una volta.",
+      "invalid_int": "Inserisci un numero intero positivo",
+      "invalid_client_id": "Inserisci l'ID client BMW CarData."
+    },
+    "abort": {
+      "auth_failed": "La risposta di autorizzazione BMW era incompleta (token mancanti). Riprova.",
+      "reauth_started": "Autorizzazione riavviata. Completa il nuovo flusso di accesso dalla notifica.",
+      "reauth_device_code_failed": "BMW ha rifiutato la richiesta di autorizzazione del dispositivo ({error}). Aggiorna l'ID client nelle opzioni dell'integrazione e riprova.",
+      "reauth_missing_client_id": "L'ID client manca per questa voce di integrazione. Rimuovi e aggiungi nuovamente l'integrazione per autorizzarti di nuovo.",
+      "reauth_failed": "La riautorizzazione non è stata avviata. Riprova dalle opzioni dell'integrazione."
+    }
+  }
+}

--- a/custom_components/cardata/translations/nl.json
+++ b/custom_components/cardata/translations/nl.json
@@ -1,0 +1,57 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "BMW Cardata",
+        "description": "Voer uw BMW CarData client-ID in."
+      },
+      "authorize": {
+        "title": "BMW CarData autoriseren",
+        "description": "Open {verification_url} en voer de gebruikerscode {user_code} in als daarom wordt gevraagd. Zodra u het apparaat heeft goedgekeurd, klikt u op Verzenden. Als de goedkeuring al is voltooid, klikt u nogmaals op Verzenden om door te gaan."
+      },
+      "blocked": {
+        "title": "Bootstrap uitgeschakeld vanwege API-snelheidslimiet",
+        "description": "De integratie heeft eerder de dagelijkse BMW API-snelheidslimiet bereikt en de automatische bootstrap (container aanmaken en mapping) is tijdelijk uitgeschakeld voor {entry_title} tot {until}. U kunt wachten tot dat moment en het opnieuw proberen, of de vlag hieronder wissen om het direct opnieuw te proberen (u kunt de snelheidslimiet opnieuw bereiken)."
+      },
+      "cleared": {
+        "title": "Bootstrap-herpoging gepland",
+        "description": "U heeft de tijdelijke uitschakel-vlag voor {entry_title} gewist. De integratie zal opnieuw proberen te bootstrappen. Als de BMW API-snelheidslimiet opnieuw wordt bereikt, zal de integratie de bootstrap weer uitschakelen tot de resettijd. U kunt ook de ontwikkelaarservice `cardata.clean_hv_containers` gebruiken om oude containers te bekijken/verwijderen (let op API-snelheidslimieten)."
+      },
+      "blocked_fallback": {
+        "description": "Automatische bootstrap is uitgeschakeld tot {until}. Wis de vlag om het nu opnieuw te proberen, of annuleer en probeer het opnieuw na de reset."
+      }
+    },
+    "error": {
+      "authorization_failed": "BMW-autorisatie is niet voltooid. Dit betekent meestal dat u op 'Weigeren' heeft geklikt, de pagina heeft gesloten voordat u goedkeurde, of de aanvraag is verlopen. Foutdetails: {error}. Verwijder de integratie en probeer deze opnieuw toe te voegen. Zorg ervoor dat u op 'Goedkeuren' klikt wanneer BMW om toestemming vraagt.",
+      "device_code_failed": "BMW heeft de apparaatautorisatieaanvraag afgewezen ({error}). Controleer of de client-ID geldig is en probeer het opnieuw."
+    },
+    "abort": {
+      "auth_failed": "Het BMW-autorisatieantwoord was onvolledig (ontbrekende tokens). Probeer het opnieuw.",
+      "reauth_device_code_failed": "BMW heeft de apparaatautorisatieaanvraag afgewezen ({error}). Werk de client-ID bij onder Configureren > Apparaatautorisatie opnieuw starten, of verwijder de integratie en voeg deze opnieuw toe.",
+      "reauth_missing_client_id": "Client-ID ontbreekt voor deze integratie-invoer. Verwijder de integratie en voeg deze opnieuw toe om opnieuw te autoriseren.",
+      "reauth_failed": "Herautorisatie kon niet worden gestart. Probeer het opnieuw vanuit de integratieopties."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Handmatige acties",
+        "description": "Selecteer de actie die u wilt uitvoeren. Tokens vernieuwen probeert alleen de tokens te vernieuwen zonder herautorisatie. We raden aan HA daarna opnieuw te starten als u problemen ondervindt."
+      }
+    },
+    "error": {
+      "refresh_failed": "Token vernieuwen mislukt: {error}",
+      "runtime_missing": "De integratie-runtime is niet gereed. Probeer het opnieuw nadat de installatie is voltooid.",
+      "no_vins": "Er zijn nog geen VIN's bekend. Wacht tot de stream een voertuig ontdekt of activeer het eenmalig handmatig.",
+      "invalid_int": "Voer een positief geheel getal in",
+      "invalid_client_id": "Voer de BMW CarData client-ID in."
+    },
+    "abort": {
+      "auth_failed": "Het BMW-autorisatieantwoord was onvolledig (ontbrekende tokens). Probeer het opnieuw.",
+      "reauth_started": "Autorisatie opnieuw gestart. Voltooi de nieuwe aanmeldprocedure vanuit de melding.",
+      "reauth_device_code_failed": "BMW heeft de apparaatautorisatieaanvraag afgewezen ({error}). Werk de client-ID bij in de integratieopties en probeer het opnieuw.",
+      "reauth_missing_client_id": "Client-ID ontbreekt voor deze integratie-invoer. Verwijder de integratie en voeg deze opnieuw toe om opnieuw te autoriseren.",
+      "reauth_failed": "Herautorisatie kon niet worden gestart. Probeer het opnieuw vanuit de integratieopties."
+    }
+  }
+}

--- a/custom_components/cardata/translations/pt.json
+++ b/custom_components/cardata/translations/pt.json
@@ -1,0 +1,57 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "BMW Cardata",
+        "description": "Introduza o seu ID de cliente BMW CarData."
+      },
+      "authorize": {
+        "title": "Autorizar BMW CarData",
+        "description": "Abra {verification_url} e introduza o código de utilizador {user_code} se solicitado. Depois de aprovar o dispositivo, clique em Submeter. Se a aprovação já foi concluída, clique novamente em Submeter para continuar."
+      },
+      "blocked": {
+        "title": "Bootstrap desativado devido ao limite de taxa da API",
+        "description": "A integração atingiu anteriormente o limite diário da API BMW e o bootstrap automático (criação de contentor e mapeamento) foi temporariamente desativado para {entry_title} até {until}. Pode esperar até esse momento e tentar novamente, ou limpar a flag abaixo para tentar imediatamente (poderá atingir o limite de taxa novamente)."
+      },
+      "cleared": {
+        "title": "Nova tentativa de bootstrap agendada",
+        "description": "Limpou a flag de desativação temporária para {entry_title}. A integração tentará o bootstrap novamente. Se o limite da API BMW for atingido novamente, a integração desativará o bootstrap até à hora de reposição. Em alternativa, use o serviço de programador `cardata.clean_hv_containers` para listar/eliminar contentores antigos (tenha em atenção os limites da API)."
+      },
+      "blocked_fallback": {
+        "description": "O bootstrap automático está desativado até {until}. Limpe a flag para tentar novamente agora, ou cancele e tente novamente após a reposição."
+      }
+    },
+    "error": {
+      "authorization_failed": "A autorização BMW não foi concluída. Isto geralmente significa que clicou em \"Recusar\", fechou a página antes de aprovar, ou o pedido expirou. Detalhes do erro: {error}. Por favor, remova a integração e tente adicioná-la novamente, certificando-se de clicar em \"Aprovar\" quando a BMW solicitar permissão.",
+      "device_code_failed": "A BMW rejeitou o pedido de autorização do dispositivo ({error}). Verifique se o ID de cliente é válido e tente novamente."
+    },
+    "abort": {
+      "auth_failed": "A resposta de autorização BMW estava incompleta (tokens em falta). Tente novamente.",
+      "reauth_device_code_failed": "A BMW rejeitou o pedido de autorização do dispositivo ({error}). Atualize o ID de cliente em Configurar > Reiniciar autorização do dispositivo, ou remova e adicione novamente a integração.",
+      "reauth_missing_client_id": "O ID de cliente está em falta para esta entrada de integração. Remova e adicione novamente a integração para se autorizar de novo.",
+      "reauth_failed": "Não foi possível iniciar a reautorização. Tente novamente a partir das opções da integração."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Ações manuais",
+        "description": "Selecione a ação que pretende executar. Atualizar tokens tenta apenas renovar os tokens sem reautorização. Sugerimos reiniciar o HA depois se tiver problemas."
+      }
+    },
+    "error": {
+      "refresh_failed": "Falha ao atualizar tokens: {error}",
+      "runtime_missing": "O ambiente de execução da integração não está pronto. Tente novamente após a configuração ser concluída.",
+      "no_vins": "Ainda não são conhecidos VINs. Aguarde que o stream descubra um veículo ou ative-o manualmente uma vez.",
+      "invalid_int": "Introduza um número inteiro positivo",
+      "invalid_client_id": "Introduza o ID de cliente BMW CarData."
+    },
+    "abort": {
+      "auth_failed": "A resposta de autorização BMW estava incompleta (tokens em falta). Tente novamente.",
+      "reauth_started": "Autorização reiniciada. Complete o novo fluxo de início de sessão a partir da notificação.",
+      "reauth_device_code_failed": "A BMW rejeitou o pedido de autorização do dispositivo ({error}). Atualize o ID de cliente nas opções da integração e tente novamente.",
+      "reauth_missing_client_id": "O ID de cliente está em falta para esta entrada de integração. Remova e adicione novamente a integração para se autorizar de novo.",
+      "reauth_failed": "Não foi possível iniciar a reautorização. Tente novamente a partir das opções da integração."
+    }
+  }
+}


### PR DESCRIPTION
Add German, French, Italian, Dutch, Spanish, and Portuguese translations for the setup wizard, error messages, and options menu. Entity names remain untranslated as they use BMW descriptor names with values and units and renaming the would break existing installations.
Those are automatic translations, I manually verified FR, NL and IT, but I can't verify DE, ES and PT.