### PR TITLE
Fix proactive MQTT reconnect not preventing hourly disconnects

### DIFF
--- a/custom_components/cardata/__init__.py
+++ b/custom_components/cardata/__init__.py
@@ -413,7 +413,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                         old_id_token = current_entry.data.get("id_token")
                         # Timeout prevents hanging indefinitely on network issues
                         await asyncio.wait_for(
-                            refresh_tokens_for_entry(current_entry, current_session, manager, container_manager),
+                            refresh_tokens_for_entry(
+                                current_entry,
+                                current_session,
+                                manager,
+                                container_manager,
+                                buffer_seconds=DEFAULT_REFRESH_INTERVAL,
+                            ),
                             timeout=60.0,
                         )
                         # Success - reset failure counters

--- a/custom_components/cardata/auth.py
+++ b/custom_components/cardata/auth.py
@@ -140,6 +140,7 @@ async def refresh_tokens_for_entry(
     session: aiohttp.ClientSession,
     manager: CardataStreamManager,
     container_manager: CardataContainerManager | None = None,
+    buffer_seconds: int = TOKEN_EXPIRY_BUFFER_SECONDS,
 ) -> None:
     """Refresh tokens and update entry data.
 
@@ -166,7 +167,7 @@ async def refresh_tokens_for_entry(
         # Lock is now acquired - use try/finally immediately to ensure release
         try:
             # double check if token still needs refesh
-            expired, seconds_left = is_token_expired(entry, TOKEN_EXPIRY_BUFFER_SECONDS)
+            expired, seconds_left = is_token_expired(entry, buffer_seconds)
             if not expired:
                 _LOGGER.debug("Token was refreshed by another caller; skipping (valid for %s seconds)", seconds_left)
                 return


### PR DESCRIPTION
The refresh loop runs every 45min but the token expiry buffer was only 5min, so tokens with ~15min left were not refreshed. Use the refresh interval as the buffer so the token is always refreshed at the 45min mark, triggering the proactive MQTT reconnect before BMW disconnects.