### PR TITLE
Add SOC prediction log to markdown table converter

### DIFF
--- a/soc_log_table.sh
+++ b/soc_log_table.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Convert SOC prediction + Magic SOC log lines to a unified markdown table.
+# Usage: ./soc_log_table.sh /tmp/hass.log
+
+FILE="${1:?usage: $0 <logfile>}"
+
+(
+  # Charging prediction (deduplicated by timestamp+VIN)
+  grep 'SOC: Predicted' "$FILE" |
+    sed 's/.*\([0-9][0-9]:[0-9][0-9]:[0-9][0-9]\)\.[0-9]*.* Predicted \([0-9.]*%\) for \([^ ]*\) (anchor=\([0-9.]*%\), +\([0-9.]* kWh\) net, eff=\([0-9]*%\)).*/\1|\3|Charging|\2 (anchor \4, +\5, \6)/' |
+    sort -t'|' -k1,2 -u
+
+  # Charging power + anchor + sync events
+  grep -E 'Power update|SOC:.*Anchored session|SOC:.*Charging started|SOC:.*Charging stopped|SOC:.*sync' "$FILE" |
+    sed \
+      -e 's/.*\([0-9][0-9]:[0-9][0-9]:[0-9][0-9]\)\.[0-9]*.* Power update for \([^ ]*\): \(.*\)/\1|\2|Power|\3/' \
+      -e 's/.*\([0-9][0-9]:[0-9][0-9]:[0-9][0-9]\)\.[0-9]*.* Anchored session for \([^ ]*\) at \(.*\)/\1|\2|Charge anchor|\3/' \
+      -e 's/.*\([0-9][0-9]:[0-9][0-9]:[0-9][0-9]\)\.[0-9]*.* Charging started for \([^ ]*\)/\1|\2|Charge start|/' \
+      -e 's/.*\([0-9][0-9]:[0-9][0-9]:[0-9][0-9]\)\.[0-9]*.* Charging stopped for \([^ ]*\)/\1|\2|Charge stop|/' \
+      -e 's/.*\([0-9][0-9]:[0-9][0-9]:[0-9][0-9]\)\.[0-9]*.* BEV \([^ ]*\) .* BMW SOC \(.*\)/\1|\2|BMW sync|\3/' \
+      -e 's/.*\([0-9][0-9]:[0-9][0-9]:[0-9][0-9]\)\.[0-9]*.* PHEV \([^ ]*\) .* BMW SOC \(.*\)/\1|\2|BMW sync|\3/' |
+    grep '|'
+
+  # Driving sessions (anchor, re-anchor, end, learning)
+  grep 'Magic SOC:' "$FILE" |
+    grep -E 'Anchor|Re-anchor|end_driving|learn|consumption' |
+    grep -v 'Skipping anchor\|Set default\|reset button\|Created' |
+    sed \
+      -e 's/.*\([0-9][0-9]:[0-9][0-9]:[0-9][0-9]\)\.[0-9]*.* Anchored driving session for \([^ ]*\) at \([0-9.]*\)% \/ \([0-9.]*\) km (consumption=\([0-9.]*\) kWh\/km)/\1|\2|Drive anchor|\3% at \4 km (cons=\5)/' \
+      -e 's/.*\([0-9][0-9]:[0-9][0-9]:[0-9][0-9]\)\.[0-9]*.* Re-anchored \([^ ]*\) from \([0-9.]*\)% to \([0-9.]*\)% at \([0-9.]*\) km/\1|\2|Re-anchor|\3% -> \4% at \5 km/' \
+      -e 's/.*\([0-9][0-9]:[0-9][0-9]:[0-9][0-9]\)\.[0-9]*.* end_driving_session for \([^ ]*\) but no active session/\1|\2|Drive end|no active session/' \
+      -e 's/.*\([0-9][0-9]:[0-9][0-9]:[0-9][0-9]\)\.[0-9]*.* Skipping learning for \([^ ]*\): \(.*\)/\1|\2|Skip learn|\3/' \
+      -e 's/.*\([0-9][0-9]:[0-9][0-9]:[0-9][0-9]\)\.[0-9]*.* Learning for \([^ ]*\): \(.*\)/\1|\2|Learned|\3/' \
+      -e 's/.*\([0-9][0-9]:[0-9][0-9]:[0-9][0-9]\)\.[0-9]*.* Ended driving session for \([^ ]*\): \(.*\)/\1|\2|Drive end|\3/' |
+    grep '|'
+) | sort -t'|' -k1,1 |
+awk -F'|' 'BEGIN {
+  print "| Time | VIN | Event | Details |"
+  print "|------|-----|-------|---------|"
+}
+{ printf "| %s | %s | %s | %s |\n", $1, $2, $3, $4 }'


### PR DESCRIPTION
That's a full SOC prediction and learning script to generate pretty markdown tables from debug logs.
Saves a lot of time.
It will show something like this:
| Time | VIN | Event | Details |
|------|-----|-------|---------|
| 08:05:50 | WBY...9486 | Drive anchor | 49.0% at 34071.0 km (cons=0.180) |
| 08:06:19 | WBY...9486 | Re-anchor | 49.0% -> 48.0% at 34071.0 km |
| 08:09:42 | WBY...9486 | Re-anchor | 48.0% -> 48.0% at 34072.0 km |
| 08:13:34 | WBY...9486 | Re-anchor | 48.0% -> 48.0% at 34073.0 km |
| 08:16:11 | WBY...9486 | Skip learn | distance 2.0 km < 5.0 km |
| 08:44:46 | WBY...9486 | Drive anchor | 46.0% at 34075.0 km (cons=0.180) |
| 08:47:46 | WBY...9486 | Re-anchor | 46.0% -> 46.0% at 34077.0 km |
| 08:50:47 | WBY...9486 | Re-anchor | 46.0% -> 46.0% at 34078.0 km |
| 08:53:47 | WBY...9486 | Re-anchor | 46.0% -> 46.0% at 34079.0 km |
| 08:56:07 | WBY...9486 | Re-anchor | 45.0% -> 45.0% at 34080.0 km |
| 08:56:07 | WBY...9486 | Re-anchor | 46.0% -> 45.0% at 34079.0 km |
| 08:58:41 | WBY...9486 | Skip learn | SOC drop 1.0% < 2.0% |
| 09:47:10 | WBY...9486 | Drive anchor | 45.0% at 34081.0 km (cons=0.180) |
| 09:50:11 | WBY...9486 | Re-anchor | 44.0% -> 44.0% at 34083.0 km |
| 09:50:11 | WBY...9486 | Re-anchor | 45.0% -> 44.0% at 34081.0 km |
| 09:52:19 | WBY...9486 | Re-anchor | 43.0% -> 43.0% at 34086.0 km |
| 09:52:19 | WBY...9486 | Re-anchor | 44.0% -> 43.0% at 34083.0 km |
| 09:55:20 | WBY...9486 | Re-anchor | 43.0% -> 43.0% at 34087.0 km |
| 09:57:06 | WBY...9486 | Re-anchor | 43.0% -> 43.0% at 34088.0 km | 
| 09:57:53 | WBY...9486 | Charge anchor | 43.0% (capacity=74.0 kWh, method=AC) |
| 09:57:53 | WBY...9486 | Charge start |  |
| 10:00:41 | WBY...9486 | Drive end | no active session |
| 10:29:07 | WBY...9486 | BMW sync | 47.0% > predicted 43.0%, syncing up |
| 10:38:32 | WBY...9486 | BMW sync | 48.0% > predicted 47.0%, syncing up |
| 10:39:54 | WBY...9486 | BMW sync | 48.0% > predicted none, syncing up |
| 10:39:54 | WBY...9486 | Charge anchor | 43.0% (capacity=74.0 kWh, method=AC) |
| 10:39:54 | WBY...9486 | Charge start |  |
| 10:39:54 | WBY...9486 | Drive end | no active session |
| 10:39:54 | WBY...9486 | Power | 6.72 kW (aux: 0.00 kW) - total energy: 0.000 kWh, predicted SOC: 43.0% |
| 10:39:59 | WBY...9486 | Charging | 48.0% (anchor 48.0%, +0.01 kWh, 90%) |
| 10:40:00 | WBY...9486 | Charging | 48.0% (anchor 48.0%, +0.01 kWh, 90%) |
| 10:40:14 | WBY...9486 | Charging | 48.0% (anchor 48.0%, +0.03 kWh, 90%) |
| 10:40:19 | WBY...9486 | Charging | 48.1% (anchor 48.0%, +0.04 kWh, 90%) |
| 10:40:44 | WBY...9486 | Charging | 48.1% (anchor 48.0%, +0.08 kWh, 90%) |
| 10:40:49 | WBY...9486 | Charging | 48.1% (anchor 48.0%, +0.09 kWh, 90%) |
| 10:41:14 | WBY...9486 | Charging | 48.2% (anchor 48.0%, +0.13 kWh, 90%) |
| 10:41:19 | WBY...9486 | Charging | 48.2% (anchor 48.0%, +0.14 kWh, 90%) |
| 10:41:44 | WBY...9486 | Charging | 48.2% (anchor 48.0%, +0.18 kWh, 90%) |


