### PR TITLE
Fix charging SOC prediction plateau during MQTT gaps

### DIFF
--- a/custom_components/cardata/soc_prediction.py
+++ b/custom_components/cardata/soc_prediction.py
@@ -1220,8 +1220,10 @@ class SOCPredictor:
                 self.update_power_reading(vin, power_kw, aux_power_kw=session.last_aux_power or 0.0)
                 updated_vins.append(vin)
 
-            # Fallback: use last known power for sessions without V×A data
-            elif session.last_power_kw > 0:
+            # Fallback: use last known power for AC sessions without V×A data.
+            # DC excluded — power tapers during charging, so replaying stale
+            # power would overestimate energy.
+            elif session.last_power_kw > 0 and session.charging_method != "DC":
                 self.update_power_reading(vin, session.last_power_kw, aux_power_kw=session.last_aux_kw)
                 updated_vins.append(vin)
 


### PR DESCRIPTION
MQTT power data arrives in sparse bursts (2-3 min of data, then 50+ min silence). The 30s periodic heartbeat kept energy counters alive during gaps, but only for AC sessions with V×A data. Vehicles like the i4 that use charging.power fallback (no acAmpere/acVoltage) were always skipped, so total_energy_kwh stopped growing after the last MQTT burst.

The read-only extrapolation in get_predicted_soc() filled the visual gap, but the fbe5e16 cap (correctly) limited it to 600s, causing massive under-prediction (~53% vs BMW's 62%) over long MQTT gaps.

Three changes:

1. periodic_update_all(): Remove the DC skip and add a fallback branch. Sessions without V×A data but with last_power_kw > 0 now get periodic energy accumulation via update_power_reading(). This covers both AC-without-V×A (i4) and DC sessions, keeping total_energy_kwh growing every 30s throughout MQTT gaps.

2. accumulate_energy(): Cap instead of skip for large time gaps. After a restart, the first call sees a large gap from the persisted timestamp. Previously this discarded all energy; now it adds up to 600s worth — a conservative but much better baseline than zero.

3. Add periodic session save during charging. _periodic_save_counter triggers persistence every 10 heartbeats (~300s). Reduces cross-restart data loss from "entire session" to ~5 minutes.

The extrapolation cap from fbe5e16 stays as a safety net — with the heartbeat keeping gaps at ~30s, the 600s cap is never reached during normal operation.

Expected: 6.7 kW AC on 74 kWh battery over 53-min gap accumulates ~6.2 kWh (106 ticks × 0.056 kWh), predicting ~58.7% vs BMW's 58%.

Verified safe for PHEVs: PHEV sync-down during charging only updates display values (last_predicted_soc), preserving anchor/energy for learning — the heartbeat doesn't re-inflate past the sync-down point because the energy-based prediction was already higher (by design). Sync-up re-anchors with fresh last_energy_update, so next heartbeat tick adds a normal small increment. No PHEV-specific code paths affected.