### PR TITLE
Fix telematics HV container auto-heal and reuse (avoid CU-124 container limit)

### DIFF
--- a/custom_components/cardata/auth.py
+++ b/custom_components/cardata/auth.py
@@ -520,15 +520,19 @@ async def async_ensure_container_for_entry(
     if runtime and runtime.container_manager:
         runtime.container_manager.sync_from_entry(container_id)
 
+    # If we reused an existing container (e.g. descriptor signature mismatch), preserve its
+    # signature so we can still prompt the user to reset the container if needed.
+    stored_signature = container_manager.container_signature or desired_signature
+
     await async_update_entry_data(
         hass,
         entry,
         {
             "hv_container_id": container_id,
-            "hv_descriptor_signature": desired_signature,
+            "hv_descriptor_signature": stored_signature,
         },
     )
-    _LOGGER.info("Created HV container %s for entry %s", container_id, entry.entry_id)
+    _LOGGER.info("Ensured HV container %s for entry %s", container_id, entry.entry_id)
 
     return True
 


### PR DESCRIPTION
After a reinstall or config restore, the stored hv_container_id can get lost. Telematics then fails with missing_container and tries to create a new one, which hits BMW's CU-124 "Maximum number of containers reached" (limit is 10, deleted ones stay around for 29 days).

The existing reuse logic only matches containers with the exact same descriptor signature, so after an update that adds new descriptors it skips the perfectly usable existing container and fails on creation.

This PR fixes three things:

1. telematics.py: When container_id is missing at fetch time, try to ensure/reuse one before giving up (auto-heal instead of immediate failure).

2. container.py: If no exact signature match is found, fall back to reusing an existing container with the same name and purpose. Logs a warning that the user can do "Reset HV Battery Container" if they want the newest descriptors.

3. auth.py: Store the actual reused container's signature so the mismatch notification works correctly.

No behavioral change when hv_container_id already exists. No extra API calls in the normal path (the loose match reuses the container list that was already fetched).

Tested by removing hv_container_id from the config entry, confirming the auto-heal kicks in, and confirming the loose reuse works when the container limit is reached.