### PR TITLE
Suppress door lock fallback log spam when not driving

### DIFF
--- a/custom_components/cardata/motion_detection.py
+++ b/custom_components/cardata/motion_detection.py
@@ -508,13 +508,13 @@ class MotionDetector:
         # Same rationale as the gap handler: check presence, not timing vs GPS.
         door_unlocked_at = self._door_unlocked_at.get(vin)
         if door_unlocked_at is not None:
-            door_state = self._door_lock_state.get(vin, "unknown")
-            _LOGGER.debug(
-                "Motion: %s door lock fallback - doors '%s' after GPS stale - NOT MOVING",
-                redact_vin(vin),
-                door_state,
-            )
             if self._is_driving.get(vin, False):
+                door_state = self._door_lock_state.get(vin, "unknown")
+                _LOGGER.debug(
+                    "Motion: %s door lock fallback - doors '%s' after GPS stale - NOT MOVING",
+                    redact_vin(vin),
+                    door_state,
+                )
                 self._is_driving[vin] = False
             return False
 


### PR DESCRIPTION
The door lock fallback logged every 30s watchdog poll when _door_unlocked_at was set, even when _is_driving was already False. Move the log inside the _is_driving guard so it only fires once on the actual driving-to-parked transition.