### PR TITLE
Fix spurious trip restart after door unlock ends trip

### DIFF
--- a/custom_components/cardata/motion_detection.py
+++ b/custom_components/cardata/motion_detection.py
@@ -477,6 +477,17 @@ class MotionDetector:
                 )
                 return False
 
+            # Door unlock override: if doors transitioned to unlocked,
+            # GPS movement is residual from the trip that just ended.
+            # When the car starts again, doors auto-lock and clear this flag.
+            door_unlocked_at = self._door_unlocked_at.get(vin)
+            if door_unlocked_at is not None:
+                _LOGGER.debug(
+                    "Motion: %s GPS movement recent but door unlocked - NOT MOVING",
+                    redact_vin(vin),
+                )
+                return False
+
             gps_change_age = (now - last_gps_change).total_seconds() / 60.0
             result = gps_change_age < self.MOTION_ACTIVE_WINDOW_MINUTES
             _LOGGER.debug(


### PR DESCRIPTION
When a trip ended via door unlock, the next GPS coordinate in the same MQTT burst bounced isMoving back to True via the gps_change_age heuristic. The not-driving branch of is_moving() did not check _door_unlocked_at, so residual GPS movement from the ended trip was misinterpreted as new driving. This created fragment trips that the watchdog killed after 2 minutes.

Add door unlock check in the not-driving fresh GPS branch, consistent with the existing guards in update_gps escape, driving mode, GPS gap, and stale GPS paths.