### PR TITLE
Fix stale SOC re-anchoring charging prediction after HA restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ The predicted SOC sensor automatically learns your vehicle's charging efficiency
 - Uses **Exponential Moving Average (EMA)** with adaptive learning rate (converges fast initially, settles to 20%)
 - Learning data persists across Home Assistant restarts
 - Active charging sessions and pending sessions survive HA restarts (restored sessions skip learning to avoid polluted data from energy gaps)
+- After HA restart, stale SOC data from previous sessions is detected and rejected using BMW-provided timestamps, preventing false re-anchoring of the predicted SOC
 
 ### Learning Requirements
 


### PR DESCRIPTION
After HA restart during active charging, restored descriptor state had last_seen set to current wall clock time (time.time() on restore), making stale data appear fresh. The header (76% from 05:53 UTC) passed the freshness check (last_seen 14:26 >= anchor 12:39) and re-anchored the session from the correct 66% to stale 76%. Prediction then climbed to 80% while actual battery was at 71%.

Root cause: freshness check used last_seen (wall clock receipt time) instead of BMW-provided timestamp. Battery descriptors (header and charging.level) always carry BMW timestamps that reflect when the value was actually measured, not when it was received.

Fix: new _is_descriptor_fresh_for_session() helper that compares the BMW timestamp field against the session anchor_timestamp. Both are timezone-aware UTC so comparison is clean. Falls back to last_seen when BMW timestamp is unavailable.

Applied to all SOC source paths:
- get_predicted_soc(): charging.level check and header fallback
- get_magic_soc(): same two checks
- process_soc_descriptors() DESC_SOC_HEADER: header freshness gate expanded from PHEV-only to all vehicles during charging, plus PHEV-specific charging.level freshness check preserved
- process_soc_descriptors() DESC_CHARGING_LEVEL: added freshness gate that was previously missing entirely