### PR TITLE
fix: add uppercase L mapping for fuel volume sensors

### DIFF
--- a/custom_components/cardata/sensor_helpers.py
+++ b/custom_components/cardata/sensor_helpers.py
@@ -92,7 +92,7 @@ def map_unit_to_ha(unit: str | None) -> str | None:
         return None
 
     unit_mapping = {
-        "l": UnitOfVolume.LITERS,
+        "L": UnitOfVolume.LITERS,
         "celsius": UnitOfTemperature.CELSIUS,
         "weeks": UnitOfTime.DAYS,
         # Note: "w" is NOT mapped here - it's ambiguous (could be watts or weeks)


### PR DESCRIPTION
Issue:
The BMW CarData API returns the fuel level unit as an uppercase "L". However, the unit_mapping in sensor_helper.py only contains the lowercase "l". This mismatch causes Home Assistant to fail to identify the sensor's unit of measurement and device class.

Impact:
Broken Metadata: Sensors lose their device_class: volume_storage, meaning they aren't properly categorized in Home Assistant.

Precision Loss: Without a recognized numeric unit, the UI defaults to integer values. Even though the integration calculates a float (e.g., 10.03L), the UI displays it as a rounded 10.

LTS Issues: Long-term statistics are not tracked correctly because the unit is technically "null" or unknown.

Proposed Change:
Explicitly add "L": UnitOfVolume.LITERS to the unit_mapping dictionary. While a global .lower() normalization is an alternative, adding the uppercase "L" explicitly is a safe with minimal-impact.

Evidence:
MQTT data from vehicle:
{"value":17,"unit":"percent"}
Current behavior displays as 10 (integer). With this fix, Home Assistant correctly identifies the unit "L" and preserves the floating-point precision (e.g., 10.03 L).

Reference:
https://developers.home-assistant.io/docs/core/entity/sensor/