### PR TITLE
Preserve existing unit when MQTT message arrives without one

### DIFF
--- a/custom_components/cardata/coordinator.py
+++ b/custom_components/cardata/coordinator.py
@@ -608,6 +608,12 @@ class CardataCoordinator:
             else:
                 value_changed = is_new or self._is_significant_change(vin, descriptor, value)
 
+            # Preserve existing unit when new message doesn't include one
+            if unit is None and not is_new:
+                existing = vehicle_state.get(descriptor)
+                if existing is not None and existing.unit is not None:
+                    unit = existing.unit
+
             vehicle_state[descriptor] = DescriptorState(
                 value=value, unit=unit, timestamp=timestamp, last_seen=time.time()
             )


### PR DESCRIPTION
MQTT messages can omit the unit field, causing the coordinator to overwrite a known unit (e.g. %) with None. This created a mismatch where device_class stayed battery but native_unit became None, triggering an HA warning for stateOfCharge.target.