### PR TITLE
PHEV: allow header sync-up during charging when above prediction

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ For Plug-in Hybrid Electric Vehicles (PHEVs), the predicted SOC has special hand
 
 - **Automatic PHEV detection**: Vehicles with both an HV battery and fuel system are detected as PHEVs, unless metadata (driveTrain/propulsionType) or the model name (e.g. i4, iX, i5) identifies them as a known BEV
 - **Sync down on battery depletion**: If the actual BMW SOC is lower than the predicted value, the prediction syncs down immediately. This handles scenarios where the hybrid system depletes the battery (e.g., battery recovery mode, engine-priority driving)
-- **Stale header filtering during charging**: When `charging.level` is available and fresh, the stale `batteryManagement.header` value is skipped to avoid corrupting the predicted SOC display
+- **Header filtering during charging**: When `charging.level` is available and fresh, `batteryManagement.header` is only allowed through if it would sync UP (header above prediction). Stale header values frozen at the pre-charge level are always below the prediction and get blocked, while legitimate mid-charge header updates above the prediction are allowed through for re-anchoring
 - **Charging level ignored for sync-down**: During charging, `charging.level` (BMW's own prediction) is ignored when lower than our energy-based prediction, which tracks the real battery more accurately
 - **BEVs**: For pure electric vehicles, the predicted SOC only syncs when not actively charging (standard behavior)
 

--- a/custom_components/cardata/soc_wiring.py
+++ b/custom_components/cardata/soc_wiring.py
@@ -555,8 +555,11 @@ def process_soc_descriptors(
                                 session.anchor_timestamp,
                             ):
                                 skip_stale_header = True
-                            # PHEV: also skip header when charging.level is fresh
-                            # (header frozen at pre-charge value while level is current)
+                            # PHEV: skip header sync-down when charging.level is fresh.
+                            # Stale header (frozen at pre-charge value) is always below
+                            # prediction — blocking sync-down catches it.  Fresh header
+                            # above prediction is a legitimate mid-charge update and must
+                            # be allowed through for re-anchoring.
                             if not skip_stale_header and soc_predictor.is_phev(vin):
                                 cl = vehicle_state.get(DESC_CHARGING_LEVEL)
                                 if (
@@ -567,7 +570,9 @@ def process_soc_descriptors(
                                         session.anchor_timestamp,
                                     )
                                 ):
-                                    skip_stale_header = True
+                                    current_predicted = soc_predictor._last_predicted_soc.get(vin)
+                                    if current_predicted is not None and soc_val < current_predicted:
+                                        skip_stale_header = True
                     if not skip_stale_header:
                         soc_predictor.update_bmw_soc(vin, soc_val)
                         magic_soc_pred.update_bmw_soc(vin, soc_val)


### PR DESCRIPTION
The write-side guard (commit 6d3cb37) blocked ALL header updates for PHEVs during charging when charging.level was fresh.  This was too aggressive: it also blocked legitimate mid-charge header updates that were above the current prediction.

On the MINI Countryman SE ALL4, header stays frozen at pre-charge value for 1-2 hours then updates with a valid reading well above the energy-based prediction.  The old guard blocked this, leaving the prediction below a known floor.

Now only block header when it would sync DOWN (header < prediction). Stale pre-charge header is always below prediction so the original bug (stale header corrupting display) is still prevented.  Fresh header above prediction is allowed through for re-anchoring.

Refs #281