### PR TITLE
Fix 3-phase charging prediction stuck at 1-phase power

### DIFF
--- a/custom_components/cardata/soc_prediction.py
+++ b/custom_components/cardata/soc_prediction.py
@@ -30,7 +30,7 @@ def _calc_ac_power_kw(session: ChargingSession) -> float | None:
         return None
     power_kw = (session.last_voltage * session.last_current) / 1000.0
     if session.phases and session.phases > 1:
-        power_kw *= 3
+        power_kw *= 3.0 if session.last_voltage < 250 else 1.732
     return power_kw
 
 

--- a/custom_components/cardata/soc_wiring.py
+++ b/custom_components/cardata/soc_wiring.py
@@ -525,6 +525,7 @@ def process_soc_descriptors(
         elif descriptor in (
             DESC_CHARGING_AC_AMPERE,
             DESC_CHARGING_AC_VOLTAGE,
+            DESC_CHARGING_PHASES,
         ):
             if soc_predictor.is_charging(vin) and soc_predictor.get_charging_method(vin) != "DC":
                 voltage = _descriptor_float(vehicle_state.get(DESC_CHARGING_AC_VOLTAGE))


### PR DESCRIPTION
phaseNumber descriptor arriving after acVoltage/acAmpere in the same MQTT burst never triggered AC power recalculation. On an i3s 120 charging at 3-phase 11 kW, the prediction used 3.63 kW (1P) and only reached 60% when the real SOC was 91%.

Also restore the voltage-dependent 3-phase multiplier (3.0 for phase voltage <250V, sqrt(3) for line-to-line >=250V).

Ref: kvanbiesen#281