### PR TITLE
Show alarm armed state on vehicle card indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Available configuration options:
 | `device_id` | *(required)* | Device ID of the BMW vehicle (from the cardata integration) |
 | `license_plate` | *(empty)* | License plate number, shown instead of VIN when set |
 | `soc_source` | `soc` | Battery level source for the bar: `soc` (BMW last known), `predicted` (charging prediction), or `magic` (driving prediction) |
-| `show_indicators` | `true` | Status indicator row (locks, doors, windows, alarm). Windows, tailgate, and hood only show red when the car is parked and locked with the item open (walked-away alert). |
+| `show_indicators` | `true` | Status indicator row (locks, doors, windows, alarm). Windows, tailgate, and hood only show red when the car is parked and locked with the item open (walked-away alert). Alarm indicator: green when armed, blue when unarmed, red when triggered. |
 | `show_range` | `true` | Battery / fuel level bar with range |
 | `show_image` | `true` | Vehicle image |
 | `show_map` | `true` | Inline location map |

--- a/custom_components/cardata/frontend/bmw-cardata-vehicle-card.js
+++ b/custom_components/cardata/frontend/bmw-cardata-vehicle-card.js
@@ -263,6 +263,10 @@ class BmwCardataVehicleCard extends HTMLElement {
             color: var(--error-color);
             border-color: transparent;
           }
+          .indicator.good {
+            color: var(--success-color);
+            border-color: transparent;
+          }
           .indicator.placeholder {
             opacity: 0;
             pointer-events: none;
@@ -773,6 +777,8 @@ class BmwCardataVehicleCard extends HTMLElement {
       Boolean(alarmActiveEntity && hasUsableState(alarmActiveStateObj)) ||
       Boolean(alarmArmingEntity && hasUsableState(alarmArmingStateObj));
     const alarmIsActive = alarmActiveState === "on" || alarmActiveState === "true";
+    const alarmArmingState = normalizeState(alarmArmingStateObj);
+    const alarmIsArmed = alarmArmingState !== "" && alarmArmingState !== "unarmed";
     const motionState = normalizeState(motionStateObj);
     const motionKnown = motionState !== "";
     const isMoving = motionState === "on" || motionState === "true" || motionState.includes("moving");
@@ -828,12 +834,10 @@ class BmwCardataVehicleCard extends HTMLElement {
       },
       {
         icon: "mdi:shield-lock",
-        stateClass: hasAlarm ? (alarmIsActive ? "ok" : "") : "",
-        entity: alarmActiveEntity || alarmArmingEntity,
+        stateClass: hasAlarm ? (alarmIsActive ? "alert" : alarmIsArmed ? "good" : "ok") : "",
+        entity: alarmArmingEntity || alarmActiveEntity,
         title: hasAlarm
-          ? (alarmActiveEntity
-            ? `Alarm: ${alarmIsActive ? "ACTIVE" : "INACTIVE"}`
-            : `Alarm arming: ${alarmArmingLabel}`)
+          ? (alarmIsActive ? "Alarm: TRIGGERED" : `Alarm: ${alarmArmingLabel || "unknown"}`)
           : "Alarm status unavailable",
       },
       {


### PR DESCRIPTION
The alarm indicator only checked alarm.isOn (alarm sounding), which is almost never true. Now uses armStatus: green when armed, blue when unarmed, red when triggered. Clicking opens the arming entity instead of the rarely-useful trigger entity.

Discussion #336