### PR TITLE
Fix phantom SOC inflation when charging stops externally + tighten bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,6 +10,8 @@ body:
 
         Please fill out all required fields — issues without debug logs will be closed.
 
+        **Reports that appear to be written or analysed by an LLM without accompanying real debug logs will be closed without investigation.** Polished code-level analysis is not a substitute for reproduction data. Using an LLM to help describe your problem is fine, but the debug logs must be real and included.
+
   - type: input
     id: ha_version
     attributes:
@@ -102,4 +104,6 @@ body:
         - label: I've searched existing issues to avoid duplicates
           required: true
         - label: I've included debug logs and version information
+          required: true
+        - label: If I used an LLM to help write this report, I have included real debug logs (not reconstructed from reading the source code)
           required: true

--- a/custom_components/cardata/const.py
+++ b/custom_components/cardata/const.py
@@ -194,6 +194,11 @@ SOC_LEARNING_STORAGE_KEY = "cardata.soc_learning"
 SOC_LEARNING_STORAGE_VERSION = 2
 # Maximum gap between energy readings before skipping integration (seconds)
 MAX_ENERGY_GAP_SECONDS = 600
+# Maximum age of the last external MQTT power update before heartbeat replay
+# and get_predicted_soc extrapolation are gated off. Prevents phantom energy
+# accumulation when BMW keeps reporting CHARGING but stops pushing power data
+# (e.g. EVSE externally stopped but BMW backend still reports the session active).
+STALE_EXTERNAL_POWER_SECONDS = 600
 
 # Driving consumption learning parameters
 DEFAULT_CONSUMPTION_KWH_PER_KM = 0.21  # BMW BEV fleet average

--- a/custom_components/cardata/soc_prediction.py
+++ b/custom_components/cardata/soc_prediction.py
@@ -33,7 +33,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from . import soc_learning
-from .const import DEFAULT_DC_EFFICIENCY, MAX_ENERGY_GAP_SECONDS
+from .const import DEFAULT_DC_EFFICIENCY, MAX_ENERGY_GAP_SECONDS, STALE_EXTERNAL_POWER_SECONDS
 from .soc_types import ChargingSession, LearnedEfficiency, PendingSession
 from .utils import redact_vin
 
@@ -311,19 +311,32 @@ class SOCPredictor:
                     session.charging_method,
                 )
 
-    def update_power_reading(self, vin: str, power_kw: float | None = None, aux_power_kw: float = 0.0) -> None:
+    def update_power_reading(
+        self,
+        vin: str,
+        power_kw: float | None = None,
+        aux_power_kw: float = 0.0,
+        *,
+        mark_fresh: bool = True,
+    ) -> None:
         """Record power update for energy accumulation.
 
         Args:
             vin: Vehicle identification number
             power_kw: Current gross charging power in kW (optional, for energy tracking)
             aux_power_kw: Auxiliary power consumption in kW (preheating, etc.)
+            mark_fresh: If True, mark the session's external power update timestamp
+                as fresh. External (MQTT/API-driven) callers leave this as True so
+                the heartbeat knows real data arrived; the heartbeat itself passes
+                False when replaying cached values to avoid self-refreshing.
         """
         session = self._sessions.get(vin)
         if session:
             # Accumulate net energy if power provided
             if power_kw is not None and power_kw >= 0:
                 session.accumulate_energy(power_kw, aux_power_kw, time.time())
+                if mark_fresh:
+                    session.last_external_power_update = time.time()
 
                 # Log every power update with current state
                 _LOGGER.debug(
@@ -490,6 +503,10 @@ class SOCPredictor:
         implied_power = energy_in_battery / (elapsed_seconds / 3600.0 * efficiency)
 
         session.last_power_kw = implied_power
+        # Fresh SOC delta counts as fresh external data for the heartbeat gate.
+        # Without this, vehicles that rely on this derivation (no charging.power
+        # telemetry) would have last_power_kw cleared on the next heartbeat tick.
+        session.last_external_power_update = time.time()
 
         _LOGGER.debug(
             "SOC: Derived charging power for %s: %.2f kW (%.1f%% -> %.1f%% over %.0f min)",
@@ -596,8 +613,15 @@ class SOCPredictor:
         # Cap gap to MAX_ENERGY_GAP_SECONDS to match accumulate_energy() —
         # without cap, long MQTT gaps inflate prediction, then "never decrease"
         # constraint locks in the inflated value creating visible plateaus.
-        if session.last_power_kw > 0 and session.last_energy_update is not None:
-            gap = time.time() - session.last_energy_update
+        # Also gated on external power freshness: if BMW hasn't pushed a real
+        # power update within STALE_EXTERNAL_POWER_SECONDS, don't extrapolate.
+        now_ts = time.time()
+        external_fresh = (
+            session.last_external_power_update is not None
+            and now_ts - session.last_external_power_update <= STALE_EXTERNAL_POWER_SECONDS
+        )
+        if session.last_power_kw > 0 and session.last_energy_update is not None and external_fresh:
+            gap = now_ts - session.last_energy_update
             if gap > 0:
                 capped_gap = min(gap, MAX_ENERGY_GAP_SECONDS)
                 net_power = max(session.last_power_kw - session.last_aux_kw, 0.0)
@@ -766,8 +790,13 @@ class SOCPredictor:
         current: float | None = None,
         phases: float | None = None,
         aux_power_kw: float | None = None,
+        *,
+        mark_fresh: bool = True,
     ) -> bool:
         """Update AC charging data and calculate power if voltage+current available.
+
+        Args:
+            mark_fresh: Propagated to update_power_reading — see that method.
 
         Returns:
             True if power was calculated and energy accumulation occurred
@@ -797,7 +826,7 @@ class SOCPredictor:
                 session.last_current,
                 session.phases,
             )
-            self.update_power_reading(vin, power_kw, aux_power_kw or 0.0)
+            self.update_power_reading(vin, power_kw, aux_power_kw or 0.0, mark_fresh=mark_fresh)
             return True
 
         return False
@@ -809,26 +838,53 @@ class SOCPredictor:
         Falls back to last_power_kw for sessions without V×A data (e.g. DC, or AC
         vehicles that only report charging.power).
 
+        Gated by session.last_external_power_update: if no real MQTT-driven power
+        update has arrived within STALE_EXTERNAL_POWER_SECONDS, replay is skipped
+        and cached power values are cleared. This prevents phantom energy
+        accumulation when BMW keeps reporting CHARGING but stops pushing power
+        data (e.g. EVSE stopped externally but BMW still reports session active).
+
         Returns:
             List of VINs that had their prediction updated
         """
         updated_vins = []
+        now = time.time()
 
         for vin, session in list(self._sessions.items()):
             if not session:
                 continue
 
+            # Freshness gate: skip replay if external power data is stale.
+            if (
+                session.last_external_power_update is None
+                or now - session.last_external_power_update > STALE_EXTERNAL_POWER_SECONDS
+            ):
+                # Clear cached power so get_predicted_soc extrapolation also stops.
+                # V×A values are left intact: if BMW resumes pushing fresh data,
+                # update_ac_charging_data will refresh them and re-arm the gate.
+                if session.last_power_kw > 0:
+                    age = (now - session.last_external_power_update) if session.last_external_power_update else -1
+                    _LOGGER.debug(
+                        "Heartbeat stale for %s (age=%.0fs) — clearing last_power_kw to freeze prediction",
+                        redact_vin(vin),
+                        age,
+                    )
+                    session.last_power_kw = 0.0
+                continue
+
             # Prefer V×A recalculation for AC sessions
             power_kw = _calc_ac_power_kw(session)
             if power_kw is not None:
-                self.update_power_reading(vin, power_kw, aux_power_kw=session.last_aux_kw)
+                self.update_power_reading(vin, power_kw, aux_power_kw=session.last_aux_kw, mark_fresh=False)
                 updated_vins.append(vin)
 
             # Fallback: use last known power for AC sessions without V×A data.
             # DC excluded — power tapers during charging, so replaying stale
             # power would overestimate energy.
             elif session.last_power_kw > 0 and session.charging_method != "DC":
-                self.update_power_reading(vin, session.last_power_kw, aux_power_kw=session.last_aux_kw)
+                self.update_power_reading(
+                    vin, session.last_power_kw, aux_power_kw=session.last_aux_kw, mark_fresh=False
+                )
                 updated_vins.append(vin)
 
         # Periodic save: every 10 updates (~300s at 30s interval)

--- a/custom_components/cardata/soc_types.py
+++ b/custom_components/cardata/soc_types.py
@@ -356,6 +356,11 @@ class ChargingSession:
     last_power_kw: float = 0.0  # Last power reading for trapezoidal integration
     last_aux_kw: float = 0.0  # Last auxiliary power for extrapolation
     last_energy_update: float | None = None  # Timestamp of last energy accumulation
+    # Timestamp of the last externally-sourced power update (MQTT or API).
+    # NOT refreshed by the heartbeat self-replay — that's the whole point: this
+    # lets the heartbeat detect when BMW has gone silent on power data and stop
+    # replaying stale values into accumulate_energy().
+    last_external_power_update: float | None = None
     target_soc: float | None = None  # Charge target from BMW (e.g. 80%)
     restored: bool = False  # True when loaded from storage (energy data incomplete)
 
@@ -380,6 +385,7 @@ class ChargingSession:
             "last_power_kw": self.last_power_kw,
             "last_aux_kw": self.last_aux_kw,
             "last_energy_update": self.last_energy_update,
+            "last_external_power_update": self.last_external_power_update,
             "target_soc": self.target_soc,
             "session_start_soc": self.session_start_soc,
             "session_total_energy_kwh": self.session_total_energy_kwh,
@@ -401,6 +407,7 @@ class ChargingSession:
             last_power_kw=data.get("last_power_kw", 0.0),
             last_aux_kw=data.get("last_aux_kw", 0.0) or data.get("last_aux_power", 0.0) or 0.0,
             last_energy_update=data.get("last_energy_update"),
+            last_external_power_update=data.get("last_external_power_update"),
             target_soc=data.get("target_soc"),
             restored=True,
             session_start_soc=data.get("session_start_soc"),


### PR DESCRIPTION
Two commits:

**`07e8ede` — Gate SOC prediction heartbeat on external power data freshness**

Fixes #355. When an EVSE is stopped externally but BMW continues to report the charging session as active without pushing fresh power updates, the 30-second heartbeat replayed the cached `last_power_kw` back through `accumulate_energy()` indefinitely, inflating the predicted SOC at a linear rate until it capped at 100%. The BEV sync-up-only rule then prevented any lower BMW SOC from correcting the value, leaving the sensor stuck at 100% until unplug.

Fix: track the timestamp of the last externally-sourced power update on `ChargingSession`. The heartbeat skips replay and clears `last_power_kw` once that timestamp is older than `STALE_EXTERNAL_POWER_SECONDS` (600s), which also stops the extrapolation in `get_predicted_soc` since both paths check `last_power_kw > 0`. Vehicles without power telemetry still work: `_derive_power_from_soc_change` refreshes the timestamp when it derives power from a BMW SOC delta, so the heartbeat continues to replay derived power between API polls.

Verified regression-free for ICE, PHEV, and BEV paths including normal AC (V×A and `charging.power`), DC fast charging, HA restart mid-session, and vehicles without power telemetry.

**`34b7c45` — Require real debug logs in bug reports**

The bug report template now states that reports written or analysed by an LLM without accompanying real debug logs will be closed without investigation, and adds a checklist item to confirm logs come from an actual reproduction.