### PR TITLE
Restore device tracker from entity registry on restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Configure it in Home Assistant via **Settings -> Devices & Services -> BMW CarDa
 
 - Each VIN becomes a device in HA (`VIN` pulled from CarData).
 - Sensors/binary sensors are auto-created and named from descriptors (e.g. `Cabin Door Row1 Driver Is Open`).
+- The device tracker (location entity) is restored from the entity registry on restart, so it keeps its last known position even before MQTT data arrives.
 - Additional attributes include the source timestamp.
 - All numeric sensors declare `suggested_display_precision`, so unit conversions (e.g. km to miles) display clean rounded values in standard HA cards and the built-in vehicle card. You can override the display unit per entity via the gear icon in the entity settings, or switch your HA unit system to imperial for a global change.
 

--- a/custom_components/cardata/device_tracker.py
+++ b/custom_components/cardata/device_tracker.py
@@ -39,6 +39,10 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_registry import (
+    async_entries_for_config_entry,
+    async_get,
+)
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import (
@@ -86,6 +90,17 @@ async def async_setup_entry(
         trackers[vin] = tracker
         async_add_entities([tracker])
         _LOGGER.debug("Created device tracker for VIN: %s", redact_vin(vin))
+
+    # Restore device trackers from entity registry so they are not
+    # "Unavailable" between restart and first MQTT data arrival.
+    entity_registry = async_get(hass)
+    for entity_entry in async_entries_for_config_entry(entity_registry, config_entry.entry_id):
+        if entity_entry.domain != "device_tracker" or entity_entry.disabled_by is not None:
+            continue
+        unique_id = entity_entry.unique_id
+        if unique_id and unique_id.endswith("_device_tracker"):
+            vin = unique_id.removesuffix("_device_tracker")
+            ensure_tracker(vin)
 
     # Create trackers for all known VINs
     for vin in coordinator.data.keys():


### PR DESCRIPTION
Fixes #354

The device tracker entity showed **Unavailable** after HA restart or integration reload because it was only created from `coordinator.data` (populated by MQTT) or live dispatcher signals. For vehicles that rarely send MQTT data (e.g. parked ICE cars), the entity was never recreated until GPS data arrived, which could take hours or never happen.

This adds entity registry restoration to the device tracker platform setup, matching the pattern already used by `sensor.py` and `binary_sensor.py`. The entity is created immediately on startup, and `RestoreEntity` provides the last known coordinates until fresh MQTT data arrives.

The `async_write_ha_state()` call from d0117f7 is preserved and still useful: it ensures HA receives the restored coordinates promptly rather than waiting for the next state write cycle.