### PR TITLE
Don't show charging when already done with charging

### DIFF
--- a/custom_components/cardata/frontend/bmw-cardata-vehicle-card.js
+++ b/custom_components/cardata/frontend/bmw-cardata-vehicle-card.js
@@ -814,6 +814,7 @@ class BmwCardataVehicleCard extends HTMLElement {
       hasCharging &&
       chargingState !== "nocharging" &&
       chargingState !== "chargingended" &&
+      chargingState !== "chargingerror" &&
       (
         chargingState.includes("charging") ||
         chargingState.includes("vehicle2grid") ||

--- a/custom_components/cardata/frontend/bmw-cardata-vehicle-card.js
+++ b/custom_components/cardata/frontend/bmw-cardata-vehicle-card.js
@@ -813,6 +813,7 @@ class BmwCardataVehicleCard extends HTMLElement {
     const chargingActive =
       hasCharging &&
       chargingState !== "nocharging" &&
+      chargingState !== "chargingended" &&
       (
         chargingState.includes("charging") ||
         chargingState.includes("vehicle2grid") ||


### PR DESCRIPTION
My bmw i4 has the state chargingended. But the system still show the pulsing bar.
Adapt so that chargingended doesn't show the pulsing bar anymore.