### PR TITLE
Redact VIN in pending_manager debug logs

### DIFF
--- a/custom_components/cardata/pending_manager.py
+++ b/custom_components/cardata/pending_manager.py
@@ -33,6 +33,8 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Generic, NamedTuple, TypeVar
 
+from .utils import redact_vin_in_text
+
 _LOGGER = logging.getLogger(__name__)
 
 T = TypeVar("T")
@@ -72,19 +74,27 @@ class PendingManager(Generic[T]):
                 _LOGGER.debug(
                     "%s already in progress for key=%s, skipping duplicate",
                     self._operation_name,
-                    key,
+                    redact_vin_in_text(str(key)),
                 )
                 return False
 
             self._pending.add(key)
-            _LOGGER.debug("%s started for key=%s", self._operation_name, key)
+            _LOGGER.debug(
+                "%s started for key=%s",
+                self._operation_name,
+                redact_vin_in_text(str(key)),
+            )
             return True
 
     async def release(self, key: T) -> None:
         """Release operation completion."""
         async with self._lock:
             self._pending.discard(key)
-            _LOGGER.debug("%s completed for key=%s", self._operation_name, key)
+            _LOGGER.debug(
+                "%s completed for key=%s",
+                self._operation_name,
+                redact_vin_in_text(str(key)),
+            )
 
 
 class PendingSnapshot(NamedTuple):


### PR DESCRIPTION
The basic_data and image_fetch PendingManager instances are keyed by
VIN, but the acquire/release/skip-duplicate debug lines logged the raw
key without redaction. Spotted by @lefebvrp in
https://github.com/kvanbiesen/bmw-cardata-ha/discussions/359#discussioncomment-16606854
while sharing logs.

Routes the key through redact_vin_in_text(str(key)) so VINs in those
messages get the same WBY...1535 treatment as everywhere else. The
helper is a regex match against the 17-char VIN pattern, so non-VIN
keys (if any future PendingManager uses non-VIN keys) pass through
untouched.