### PR TITLE
Add charging profile mode descriptor to HV battery container

### DIFF
--- a/custom_components/cardata/const.py
+++ b/custom_components/cardata/const.py
@@ -147,6 +147,7 @@ HV_BATTERY_DESCRIPTORS = [
     "vehicle.drivetrain.electricEngine.charging.timeToFullyCharged",
     "vehicle.powertrain.electric.battery.charging.acLimit.selected",
     "vehicle.drivetrain.electricEngine.charging.method",
+    "vehicle.drivetrain.electricEngine.charging.profile.mode",
     "vehicle.body.chargingPort.plugEventId",
     DESC_CHARGING_PHASES,
     DESC_TRIP_HVSOC,


### PR DESCRIPTION
Adds vehicle.drivetrain.electricEngine.charging.profile.mode to
HV_BATTERY_DESCRIPTORS so the active charging profile (immediate,
delayed, etc.) becomes visible as a sensor again. The descriptor is
already mapped in descriptor_titles.py but was never included in any
container, so BMW never streamed it.

Reported by @lefebvrp in
https://github.com/kvanbiesen/bmw-cardata-ha/discussions/359#discussioncomment-16611259
who confirmed it is still selectable in the BMW CarData portal.

The JjyKsi integration exposed this descriptor and users with custom
charging automations relied on it as an unambiguous source of truth
rather than inferring the profile from charging.status edges.