### PR TITLE
Add external power meter injection for charging SOC prediction

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,33 @@ Magic SOC predicts battery drain during driving using real-time odometer distanc
 
 **Limitations**: This is experimental. Accuracy depends on BMW sending timely SOC and mileage data. Preheating, extended idle with accessories, and firmware glitches can cause temporary inaccuracy. PHEVs are excluded from prediction (hybrid powertrain makes distance-based estimation unreliable).
 
+## External Power Meter Injection (Optional)
+
+If you have a smart meter that reports the power delivered to the car, you can feed its readings into the SOC predictor and bypass BMW's V×A telemetry, which is refreshed only every ~5 hours on some models and returns sentinel zero values during fast EVSE flapping (see discussion [#359](https://github.com/kvanbiesen/bmw-cardata-ha/discussions/359)). **Disabled by default.**
+
+- **Enable via**: Settings → Devices & Services → BMW CarData → Configure → Settings → Use external power meter for charging
+- **Service**: `cardata.update_charging_power` with fields `vin`, `power_kw`, and optional `aux_power_kw`.
+- **Precedence**: Freshness-based. While a local reading has arrived within the last 120 seconds, BMW-sourced V×A and `charging.power` updates are suppressed. When local readings stop (car driven away, meter offline), the predictor falls back to BMW after the timeout — no manual switching needed.
+- **Typical setup**: A Home Assistant automation that triggers on your meter's power sensor changes (or on a 10–30 second interval) and calls the service with the current reading. **Gate the automation on the car being home** — otherwise the meter will happily push 0 W while the car is away at a public charger, holding the freshness gate and blocking BMW's V×A updates from the public session.
+
+```yaml
+automation:
+  - trigger:
+      - platform: state
+        entity_id: sensor.my_ev_meter_power
+    condition:
+      - condition: state
+        entity_id: device_tracker.my_bmw
+        state: home
+    action:
+      - service: cardata.update_charging_power
+        data:
+          vin: "WBY31AW090FP15359"
+          power_kw: "{{ states('sensor.my_ev_meter_power') | float / 1000 }}"
+```
+
+When the option is disabled, the service no-ops with a warning — leaving it always registered so automations do not break across reloads.
+
 ## Charging History (Optional)
 
 The integration can fetch your BMW charging session history from the past 30 days. This is **disabled by default** to conserve your API quota.
@@ -379,6 +406,7 @@ Home Assistant's Developer Tools expose helper services for manual API checks:
 - `cardata.fetch_vehicle_images` manually fetches vehicle images for all configured vehicles.
 - `cardata.clean_hv_containers` lists or deletes high-voltage battery telemetry containers (actions: `list`, `delete`, `delete_all`, `delete_all_matching`).
 - `cardata.migrate_entity_ids` migrates entity IDs from old format to new format. Use `dry_run` to preview changes without applying them.
+- `cardata.update_charging_power` injects a locally measured charging power reading (kW) into the SOC predictor. Requires the **Use external power meter for charging** option to be enabled under Settings. Intended for users with a smart meter who want to feed accurate real-time power into the prediction instead of relying on BMW's V×A — see the section below.
 
 ## API Quota and MQTT Streaming
 

--- a/custom_components/cardata/const.py
+++ b/custom_components/cardata/const.py
@@ -123,6 +123,13 @@ OPTION_ENABLE_CHARGING_HISTORY = "enable_charging_history"
 OPTION_ENABLE_TYRE_DIAGNOSIS = "enable_tyre_diagnosis"
 OPTION_ENABLE_TRIP_POLL = "enable_trip_end_polling"
 OPTION_TRIP_POLL_COOLDOWN = "trip_poll_cooldown_minutes"
+OPTION_ENABLE_EXTERNAL_POWER = "enable_external_power_injection"
+
+# Freshness window for externally injected charging power. While a local
+# injection has arrived within this many seconds, BMW-sourced V×A and
+# charging.power updates are suppressed so they do not overwrite the user's
+# meter data with stale BMW values.
+LOCAL_POWER_TTL_SECONDS = 120
 
 # Error message constants (for consistent error detection)
 ERR_TOKEN_REFRESH_IN_PROGRESS = "Token refresh already in progress"

--- a/custom_components/cardata/options_flow.py
+++ b/custom_components/cardata/options_flow.py
@@ -50,6 +50,7 @@ from .const import (
     OPTION_CUSTOM_MQTT_TOPIC_PREFIX,
     OPTION_CUSTOM_MQTT_USERNAME,
     OPTION_ENABLE_CHARGING_HISTORY,
+    OPTION_ENABLE_EXTERNAL_POWER,
     OPTION_ENABLE_MAGIC_SOC,
     OPTION_ENABLE_TRIP_POLL,
     OPTION_ENABLE_TYRE_DIAGNOSIS,
@@ -175,6 +176,7 @@ class CardataOptionsFlowHandler(config_entries.OptionsFlow):
             options[OPTION_ENABLE_TYRE_DIAGNOSIS] = user_input[OPTION_ENABLE_TYRE_DIAGNOSIS]
             options[OPTION_ENABLE_TRIP_POLL] = user_input[OPTION_ENABLE_TRIP_POLL]
             options[OPTION_TRIP_POLL_COOLDOWN] = cooldown
+            options[OPTION_ENABLE_EXTERNAL_POWER] = user_input[OPTION_ENABLE_EXTERNAL_POWER]
             return self.async_create_entry(title="", data=options)
 
         current_magic = self._config_entry.options.get(OPTION_ENABLE_MAGIC_SOC, False)
@@ -182,6 +184,7 @@ class CardataOptionsFlowHandler(config_entries.OptionsFlow):
         current_td = self._config_entry.options.get(OPTION_ENABLE_TYRE_DIAGNOSIS, False)
         current_trip = self._config_entry.options.get(OPTION_ENABLE_TRIP_POLL, True)
         current_cooldown = self._config_entry.options.get(OPTION_TRIP_POLL_COOLDOWN, DEFAULT_TRIP_POLL_COOLDOWN_MINUTES)
+        current_ext_power = self._config_entry.options.get(OPTION_ENABLE_EXTERNAL_POWER, False)
         return self.async_show_form(
             step_id="action_settings",
             data_schema=vol.Schema(
@@ -191,6 +194,7 @@ class CardataOptionsFlowHandler(config_entries.OptionsFlow):
                     vol.Optional(OPTION_ENABLE_TYRE_DIAGNOSIS, default=current_td): bool,
                     vol.Optional(OPTION_ENABLE_TRIP_POLL, default=current_trip): bool,
                     vol.Optional(OPTION_TRIP_POLL_COOLDOWN, default=current_cooldown): int,
+                    vol.Optional(OPTION_ENABLE_EXTERNAL_POWER, default=current_ext_power): bool,
                 }
             ),
         )

--- a/custom_components/cardata/services.py
+++ b/custom_components/cardata/services.py
@@ -54,6 +54,9 @@ from .const import (
     HTTP_TIMEOUT,
     HV_BATTERY_CONTAINER_NAME,
     HV_BATTERY_CONTAINER_PURPOSE,
+    MAGIC_SOC_DESCRIPTOR,
+    OPTION_ENABLE_EXTERNAL_POWER,
+    PREDICTED_SOC_DESCRIPTOR,
 )
 from .runtime import CardataRuntimeData, async_update_entry_data
 from .utils import (
@@ -96,6 +99,15 @@ CLEAN_CONTAINERS_SCHEMA = vol.Schema(
         vol.Optional("entry_id"): str,
         vol.Optional("action", default="list"): vol.In(["list", "delete", "delete_all", "delete_all_matching"]),
         vol.Optional("container_id"): str,
+    }
+)
+
+UPDATE_CHARGING_POWER_SCHEMA = vol.Schema(
+    {
+        vol.Optional("entry_id"): str,
+        vol.Required("vin"): str,
+        vol.Required("power_kw"): vol.Coerce(float),
+        vol.Optional("aux_power_kw", default=0.0): vol.Coerce(float),
     }
 )
 
@@ -572,6 +584,73 @@ async def async_handle_clean_containers(call: ServiceCall) -> None:
     _LOGGER.error("clean_hv_containers: unknown action '%s'", action)
 
 
+async def async_handle_update_charging_power(call: ServiceCall) -> None:
+    """Inject locally measured charging power into the SOC predictor.
+
+    Gated by OPTION_ENABLE_EXTERNAL_POWER on the config entry — the service
+    is always registered so automations do not break on reload, but calls
+    no-op with a warning when the option is disabled.
+    """
+    hass = call.hass
+    resolved = _resolve_target(hass, call.data)
+    if not resolved:
+        return
+
+    _target_entry_id, target_entry, runtime = resolved
+
+    if not target_entry.options.get(OPTION_ENABLE_EXTERNAL_POWER, False):
+        _LOGGER.warning("Cardata update_charging_power: enable_external_power_injection option is off; ignoring call")
+        return
+
+    vin = call.data.get("vin")
+    if not vin or not is_valid_vin(vin):
+        _LOGGER.error("Cardata update_charging_power: invalid or missing VIN")
+        return
+
+    power_kw = float(call.data["power_kw"])
+    if power_kw < 0:
+        _LOGGER.error(
+            "Cardata update_charging_power: negative power (%.3f kW) rejected for %s",
+            power_kw,
+            redact_vin(vin),
+        )
+        return
+
+    aux_power_kw = float(call.data.get("aux_power_kw", 0.0) or 0.0)
+
+    coordinator = getattr(runtime, "coordinator", None)
+    soc_predictor = getattr(coordinator, "_soc_predictor", None) if coordinator else None
+    if soc_predictor is None or coordinator is None:
+        _LOGGER.error("Cardata update_charging_power: SOC predictor not available")
+        return
+
+    magic_soc_pred = getattr(coordinator, "_magic_soc", None)
+    schedule_debounce = False
+    async with coordinator._lock:
+        soc_predictor.update_power_reading(vin, power_kw, aux_power_kw, from_local=True)
+        if soc_predictor.is_charging(vin):
+            if soc_predictor.has_signaled_entity(vin) and coordinator._pending_manager.add_update(
+                vin, PREDICTED_SOC_DESCRIPTOR
+            ):
+                schedule_debounce = True
+            if (
+                magic_soc_pred is not None
+                and magic_soc_pred.has_signaled_magic_soc_entity(vin)
+                and coordinator._pending_manager.add_update(vin, MAGIC_SOC_DESCRIPTOR)
+            ):
+                schedule_debounce = True
+
+    if schedule_debounce:
+        await coordinator._async_schedule_debounced_update()
+
+    _LOGGER.debug(
+        "Cardata update_charging_power: injected %.2f kW (aux %.2f kW) for %s",
+        power_kw,
+        aux_power_kw,
+        redact_vin(vin),
+    )
+
+
 def async_register_services(hass: HomeAssistant) -> None:
     """Register all Cardata services."""
     hass.services.async_register(
@@ -610,6 +689,12 @@ def async_register_services(hass: HomeAssistant) -> None:
         async_handle_fetch_tyre_diagnosis,
         schema=DAILY_FETCH_SERVICE_SCHEMA,
     )
+    hass.services.async_register(
+        DOMAIN,
+        "update_charging_power",
+        async_handle_update_charging_power,
+        schema=UPDATE_CHARGING_POWER_SCHEMA,
+    )
 
     # Developer migration service
     if not hass.services.has_service(DOMAIN, "migrate_entity_ids"):
@@ -642,6 +727,7 @@ def async_unregister_services(hass: HomeAssistant) -> None:
         "fetch_vehicle_images",
         "fetch_charging_history",
         "fetch_tyre_diagnosis",
+        "update_charging_power",
     ):
         if hass.services.has_service(DOMAIN, service):
             hass.services.async_remove(DOMAIN, service)

--- a/custom_components/cardata/services.yaml
+++ b/custom_components/cardata/services.yaml
@@ -89,3 +89,38 @@ fetch_tyre_diagnosis:
     vin:
       description: Optional VIN to query. If omitted, fetches for all known VINs.
       example: WBY31AW090FP15359
+update_charging_power:
+  name: Update Charging Power
+  description: >
+    Inject a locally measured charging power reading into the SOC predictor.
+    While a local reading is fresh, BMW-sourced V×A values are suppressed so
+    the meter's view wins. Requires the "Use external power meter for charging"
+    option to be enabled for the entry. Intended to be called repeatedly from an
+    automation driven by a smart meter (e.g. every 10-30 seconds).
+  fields:
+    entry_id:
+      description: Optional config entry id to target. Required if multiple entries are configured.
+      example: 01K65NKFESKBQZ78PBW6V9BCCX
+    vin:
+      description: VIN of the vehicle being charged.
+      required: true
+      example: WBY31AW090FP15359
+    power_kw:
+      description: Gross charging power delivered to the vehicle, in kW.
+      required: true
+      example: 2.3
+      selector:
+        number:
+          min: 0
+          max: 350
+          step: 0.01
+          unit_of_measurement: kW
+    aux_power_kw:
+      description: Optional auxiliary (preheating etc.) power in kW. Defaults to 0.
+      example: 0.3
+      selector:
+        number:
+          min: 0
+          max: 10
+          step: 0.01
+          unit_of_measurement: kW

--- a/custom_components/cardata/soc_prediction.py
+++ b/custom_components/cardata/soc_prediction.py
@@ -33,7 +33,12 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from . import soc_learning
-from .const import DEFAULT_DC_EFFICIENCY, MAX_ENERGY_GAP_SECONDS, STALE_EXTERNAL_POWER_SECONDS
+from .const import (
+    DEFAULT_DC_EFFICIENCY,
+    LOCAL_POWER_TTL_SECONDS,
+    MAX_ENERGY_GAP_SECONDS,
+    STALE_EXTERNAL_POWER_SECONDS,
+)
 from .soc_types import ChargingSession, LearnedEfficiency, PendingSession
 from .utils import redact_vin
 
@@ -133,6 +138,11 @@ class SOCPredictor:
 
         # Counter for periodic save during charging (every 10 heartbeats)
         self._periodic_save_counter: int = 0
+
+        # VIN -> monotonic timestamp of last externally-injected (local meter)
+        # power reading. While this is fresh, BMW-sourced V×A / charging.power
+        # updates are suppressed. See LOCAL_POWER_TTL_SECONDS.
+        self._last_local_power_update: dict[str, float] = {}
 
     def set_learning_callback(self, callback: Callable[[], None]) -> None:
         """Set callback to be called when learning data is updated.
@@ -318,6 +328,7 @@ class SOCPredictor:
         aux_power_kw: float = 0.0,
         *,
         mark_fresh: bool = True,
+        from_local: bool = False,
     ) -> None:
         """Record power update for energy accumulation.
 
@@ -329,14 +340,32 @@ class SOCPredictor:
                 as fresh. External (MQTT/API-driven) callers leave this as True so
                 the heartbeat knows real data arrived; the heartbeat itself passes
                 False when replaying cached values to avoid self-refreshing.
+            from_local: True when the reading was injected by the user's local
+                meter via the update_charging_power service. When False (BMW or
+                heartbeat origin), the call is suppressed while a local injection
+                is still fresh (see LOCAL_POWER_TTL_SECONDS) so BMW's stale V×A
+                cannot overwrite the meter's view.
         """
+        now = time.time()
+        if from_local:
+            self._last_local_power_update[vin] = now
+        else:
+            last_local = self._last_local_power_update.get(vin)
+            if last_local is not None and now - last_local <= LOCAL_POWER_TTL_SECONDS:
+                _LOGGER.debug(
+                    "Skipping BMW power update for %s: local injection is fresh (%.1fs ago)",
+                    redact_vin(vin),
+                    now - last_local,
+                )
+                return
+
         session = self._sessions.get(vin)
         if session:
             # Accumulate net energy if power provided
             if power_kw is not None and power_kw >= 0:
-                session.accumulate_energy(power_kw, aux_power_kw, time.time())
+                session.accumulate_energy(power_kw, aux_power_kw, now)
                 if mark_fresh:
-                    session.last_external_power_update = time.time()
+                    session.last_external_power_update = now
 
                 # Log every power update with current state
                 _LOGGER.debug(

--- a/custom_components/cardata/translations/en.json
+++ b/custom_components/cardata/translations/en.json
@@ -45,13 +45,15 @@
           "enable_charging_history": "Enable Charging History (daily API poll)",
           "enable_tyre_diagnosis": "Enable Tyre Diagnosis (daily API poll)",
           "enable_trip_end_polling": "Enable trip-end polling",
-          "trip_poll_cooldown_minutes": "Trip-end poll cooldown (minutes)"
+          "trip_poll_cooldown_minutes": "Trip-end poll cooldown (minutes)",
+          "enable_external_power_injection": "Use external power meter for charging"
         },
         "data_description": {
           "enable_charging_history": "Fetches charging session history from BMW once per day. Uses 1 additional API call per vehicle per day from your 50-call daily quota.",
           "enable_tyre_diagnosis": "Fetches tyre health and wear data from BMW once per day. Uses 1 additional API call per vehicle per day from your 50-call daily quota.",
           "enable_trip_end_polling": "When enabled, triggers an immediate API poll each time the vehicle stops. Disable this if you make many short trips and hit the daily API limit. Scheduled polling still runs regardless.",
-          "trip_poll_cooldown_minutes": "Minimum wait between trip-end polls for the same vehicle (default: 10). Increase this to reduce API usage on frequent short trips."
+          "trip_poll_cooldown_minutes": "Minimum wait between trip-end polls for the same vehicle (default: 10). Increase this to reduce API usage on frequent short trips.",
+          "enable_external_power_injection": "Allow an automation to push locally measured charging power to the SOC predictor via the cardata.update_charging_power service. While fresh local readings arrive, BMW-sourced V×A is suppressed. Leave off unless you run a smart meter and have wired it up."
         }
       },
       "action_mqtt_broker": {


### PR DESCRIPTION
Closes #364. Follows up on discussion #359.

Adds an opt-in service `cardata.update_charging_power(vin, power_kw, aux_power_kw?)` that lets users feed locally measured charging power into the SOC predictor. When fresh local readings are available the predictor prefers them over BMW-sourced V×A and `charging.power`; once local readings stop arriving (car driven away, meter offline, automation stopped) the predictor falls back to BMW automatically after a 120s freshness window.

**Design:**
- Freshness-based precedence. Local wins for 120s after the most recent push; otherwise BMW wins. No mode toggle, no explicit switching, no location awareness inside the integration.
- Gated behind a new default-off option `enable_external_power_injection` in the Settings step. When off, the service is still registered (so automations survive reloads) but calls no-op with a warning.
- Single new field on the predictor: `_last_local_power_update: dict[str, float]`, keyed by VIN. The BMW-fed path (AC V×A, DC `charging.power`, heartbeat replay, reconnect restore) gains one freshness check in `update_power_reading`. Nothing else in the predictor changes — anchor, accumulation, re-anchoring, session lifecycle, learning — all intact.

**Regression guarantees:**
- Option off (default for all existing users): `_last_local_power_update` stays empty, gate check returns `None`, never fires. Zero behavioural change.
- Option on but service never called: same — empty dict, gate dormant.
- Option on + service called: well-defined freshness gate.

**User responsibility:** the automation decides *when* to inject. The README example gates on `device_tracker.<car>: home`. Multiple meters at multiple homes work naturally — each automation conditions on its own zone, per-VIN timestamp handles arbitration.

Verified with ruff/ruff-format/mypy clean. No persistence schema changes. HA restart drops the timestamp, first local inject re-arms the gate — correct fallback behaviour.