### PR TITLE
Add more humanized strings

### DIFF
--- a/custom_components/cardata/frontend/bmw-cardata-vehicle-card.js
+++ b/custom_components/cardata/frontend/bmw-cardata-vehicle-card.js
@@ -104,9 +104,20 @@ const humanizeStateValue = (rawState) => {
   const normalized = String(rawState).trim().toLowerCase();
   if (!normalized || normalized === "unknown" || normalized === "unavailable") return "—";
   switch (normalized) {
+    // charging state
     case "CHARGINGACTIVE": return "Charging Active";
     case "CHARGINGENDED": return "Charging Ended";
     case "NOCHARGING": return "No Charging";
+    // doors
+    case "SECURED": return "Secured";
+    case "UNLOCKED": return "Unlocked";
+    // alarm
+    case "doorsTiltCabin": return "Doors, Tilt, Cabin";
+    case "doorsOnly": return "Doors Only";
+    case "unarmed": return "Unarmed";
+    // windows
+    case "CLOSED": return "Closed";
+    case "INTERMEDIATE": return "Intermediate";
   }
   return normalized
     .replaceAll("_", " ")


### PR DESCRIPTION
Relevant to #370 and the corresponding fix (https://github.com/kvanbiesen/bmw-cardata-ha/commit/9bcdd1b09c7aeab31a76f5dbef915aa368f7eae8), I added a few more states that aren't displayed neatly at the moment.
<img width="335" height="325" alt="image" src="https://github.com/user-attachments/assets/8bb7b91d-9f80-4d31-81a5-c2abd9d7babd" />
<img width="319" height="334" alt="image" src="https://github.com/user-attachments/assets/0752f9a7-c6f8-4bbe-9d2e-17f6a75c1b41" />
<img width="298" height="342" alt="image" src="https://github.com/user-attachments/assets/2311cdf7-5ef6-43f2-a3da-7a4c2beee13e" />
