### PR TITLE
Flush pending charging energy before SOC re-anchor

### DIFF
--- a/custom_components/cardata/soc_prediction.py
+++ b/custom_components/cardata/soc_prediction.py
@@ -437,6 +437,7 @@ class SOCPredictor:
                             session.last_energy_update = time.time()
                         else:
                             # Charging, from real battery (header): full re-anchor downward
+                            session.flush_pending_energy()
                             old_anchor = session.anchor_soc
                             ref_time = session.last_energy_update or session.anchor_timestamp.timestamp()
                             session.anchor_soc = soc
@@ -458,6 +459,7 @@ class SOCPredictor:
                     self._last_predicted_soc[vin] = soc
                     session = self._sessions.get(vin)
                     if session is not None:
+                        session.flush_pending_energy()
                         old_anchor = session.anchor_soc
                         ref_time = session.last_energy_update or session.anchor_timestamp.timestamp()
                         session.anchor_soc = soc
@@ -479,6 +481,7 @@ class SOCPredictor:
                 # consistent state (prevents race with SyncWorker reads)
                 session = self._sessions.get(vin)
                 if session is not None:
+                    session.flush_pending_energy()
                     old_anchor = session.anchor_soc
                     ref_time = session.last_energy_update or session.anchor_timestamp.timestamp()
                     session.anchor_soc = soc

--- a/custom_components/cardata/soc_types.py
+++ b/custom_components/cardata/soc_types.py
@@ -28,6 +28,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
@@ -442,3 +443,16 @@ class ChargingSession:
         self.last_power_kw = power_kw
         self.last_aux_kw = aux_power_kw
         self.last_energy_update = timestamp
+
+    def flush_pending_energy(self, now: float | None = None) -> None:
+        """Credit energy delivered at last known power up to ``now``.
+
+        Called before a re-anchor so the energy accrued between the last
+        power telemetry update and the re-anchor moment is captured in
+        session_total_energy_kwh instead of being silently dropped when
+        last_energy_update is fast-forwarded to "now". No-op when there is
+        no previous power reading to extrapolate from.
+        """
+        if self.last_power_kw <= 0 or self.last_energy_update is None:
+            return
+        self.accumulate_energy(self.last_power_kw, self.last_aux_kw, now if now is not None else time.time())


### PR DESCRIPTION
Each BMW SOC sync-up wiped last_energy_update without first integrating the energy delivered since the last charging.power push, dropping that slice from session_total_energy_kwh. With sparse DC power telemetry and re-anchors firing every ~1pp, this starved the learning input: a 16 minute 24 to 60 percent DC session captured only 1.76 kWh of the ~25 kWh actually delivered, producing efficiency 14.55 and getting discarded.

Add ChargingSession.flush_pending_energy() that integrates at the last known power up to now, and call it before each live re-anchor. No-op when there is no real power telemetry, so vehicles relying on derived power are unaffected.