### PR TITLE
Fix CU-105 container invalidation handling and charging method restore

### DIFF
--- a/custom_components/cardata/http_retry.py
+++ b/custom_components/cardata/http_retry.py
@@ -138,9 +138,20 @@ class HttpResponse:
         return False
 
     @property
+    def is_container_invalid(self) -> bool:
+        """Check if response indicates the requested container is invalid.
+
+        BMW returns CU-105 ("No permission for specified containerId") as HTTP 403
+        when the container has been deleted or unlinked on their side. Distinct
+        from a real auth error: the OAuth token is fine, only the stored
+        container_id needs to be re-discovered.
+        """
+        return self.status == 403 and "CU-105" in self.text
+
+    @property
     def is_auth_error(self) -> bool:
         """Check if response indicates authentication error."""
-        if self.is_rate_limited:
+        if self.is_rate_limited or self.is_container_invalid:
             return False
         return self.status in (401, 403)
 

--- a/custom_components/cardata/soc_learning.py
+++ b/custom_components/cardata/soc_learning.py
@@ -102,6 +102,8 @@ def load_session_data(predictor: SOCPredictor, data: dict[str, Any]) -> None:
             session = ChargingSession.from_dict(s_data)
             predictor._sessions[vin] = session
             predictor._last_predicted_soc[vin] = session.last_predicted_soc
+            if session.charging_method:
+                predictor._charging_method[vin] = session.charging_method
         except Exception as err:
             _LOGGER.warning("SOC: Failed to load active session for %s: %s", redact_vin(vin), err)
 

--- a/custom_components/cardata/telematics.py
+++ b/custom_components/cardata/telematics.py
@@ -186,6 +186,7 @@ async def async_perform_telematic_fetch(
     any_attempt = False
     auth_failure = False
     rate_limited = False
+    container_invalid = False
     all_skipped = True  # Track if we skipped all VINs due to fresh MQTT
 
     for vin in vins:
@@ -243,6 +244,24 @@ async def async_perform_telematic_fetch(
                 )
                 continue
 
+            # Container invalidated by BMW (CU-105): token is fine, but the
+            # stored container_id is no longer accepted. Clear it so the next
+            # bootstrap re-discovers / recreates a container.
+            if response.is_container_invalid:
+                _LOGGER.warning(
+                    "Cardata fetch_telematic_data: container %s no longer valid for %s "
+                    "(CU-105); clearing stored container so next restart re-bootstraps",
+                    cid,
+                    redacted_vin,
+                )
+                await async_update_entry_data(
+                    hass,
+                    entry,
+                    {"hv_container_id": None, BOOTSTRAP_COMPLETE: False},
+                )
+                container_invalid = True
+                break  # Stop trying other containers
+
             # Check for auth errors - these are fatal and require reauth
             if response.is_auth_error:
                 _LOGGER.error(
@@ -284,7 +303,7 @@ async def async_perform_telematic_fetch(
             if isinstance(telematic_payload, dict):
                 merged_data.update(telematic_payload)
 
-        if auth_failure or rate_limited:
+        if auth_failure or rate_limited or container_invalid:
             break  # Stop trying other VINs
 
         if merged_data:
@@ -296,6 +315,11 @@ async def async_perform_telematic_fetch(
     if all_skipped:
         _LOGGER.debug("All VINs have fresh MQTT data, skipping scheduled poll")
         return TelematicFetchResult(True)
+
+    # Container was invalidated by BMW; bootstrap flag has been cleared so the
+    # next restart will re-discover. Don't trigger the reauth flow.
+    if container_invalid:
+        return TelematicFetchResult(None, "container_invalid")
 
     # Auth failure is fatal - signal reauth needed
     if auth_failure:


### PR DESCRIPTION
Two unrelated fixes.

### CU-105: invalid container, not auth error
BMW returns HTTP 403 with `exveErrorId=CU-105` when a stored `container_id` is no longer valid. Previously this was routed through the auth-error path, triggering bogus "reauth may be required" logs and 120-minute backoff escalation, even though the token was fine.

Now classified separately: clears `hv_container_id` and `BOOTSTRAP_COMPLETE` so the next restart re-bootstraps a fresh container, and is excluded from the reauth path.

### Restore charging method on session reload
After HA restart during active charging, `_charging_method` was empty because `load_session_data` only restored `_sessions`, not the parallel dict. For AC vehicles without V×A telemetry (i4 eDrive40), the `charging.power` wiring gate dropped every MQTT update, leaving only heartbeat replay of cached `last_power_kw` — which froze once it hit `STALE_EXTERNAL_POWER_SECONDS`.