### PR TITLE
Add travelledDistance to the HV battery container

### DIFF
--- a/custom_components/cardata/const.py
+++ b/custom_components/cardata/const.py
@@ -176,6 +176,9 @@ HV_BATTERY_DESCRIPTORS = [
     DESC_MAX_ENERGY,
     DESC_CHARGING_POWER,
     DESC_CHARGING_STATUS,
+    # API fallback for vehicles where MQTT goes silent on the odometer
+    # descriptor (issue #377). Mileage previously only arrived via MQTT.
+    DESC_TRAVELLED_DISTANCE,
 ]
 
 # Minimum number of telemetry descriptors required to consider a vehicle as "real"


### PR DESCRIPTION
When BMW MQTT goes silent on a VIN (single-descriptor or whole-stream) the integration had no way to refresh mileage — `vehicle.vehicle.travelledDistance` was only ever delivered via MQTT and wasn't requested via the API container. Issue #377 confirmed this on an iX2 where MyBMW shows the current value but the integration's cached mileage stayed at the late-March MQTT push.

Add the descriptor to `HV_BATTERY_DESCRIPTORS` so the 30-minute telematic poll picks it up as a fallback. The signature-mismatch path in `auth.ensure_hv_container` deletes the old container and creates a fresh one on first startup after the update (~3 API calls, one-off).

For users with a healthy MQTT stream the behaviour is unchanged. When MQTT silences specifically on this descriptor (or across the whole VIN), the API keeps the entity moving — provided BMW's backend has a fresh value to return. If it doesn't, the entity stays at its current value, no regression.