### PR TITLE
Improve debug log redaction guidance in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -74,14 +74,23 @@ body:
       label: Debug logs
       description: |
         Enable debug logging, reproduce the issue, and paste the logs here.
-        Please remove or redact personal data (VIN, location, tokens, etc.).
+
+        The integration already redacts VINs (e.g. `WBY...9486`) and bearer
+        tokens / Authorization headers in error messages. You only need to
+        redact things it doesn't auto-redact: account email, precise GPS
+        coordinates, and anything visible in attached screenshots.
+
+        Please leave entry IDs (UUID-like), container IDs (e.g.
+        `G00B025F732UD`), GCIDs, and BMW descriptor names visible — they're
+        internal identifiers, not personal data, and removing them makes
+        diagnosis harder.
 
         Enable debug logging by adding this to your configuration.yaml:
         ```yaml
         logger:
           default: info
           logs:
-            custom_components.bmw_cardata: debug
+            custom_components.cardata: debug
         ```
         or set debug_log in const.py to true and restart HA.
       render: text


### PR DESCRIPTION
The template told users to "remove or redact personal data (VIN, location, tokens, etc.)" without acknowledging that the integration already redacts VINs (`XXX...YYYY` form via `redact_vin()`) and bearer tokens / Authorization headers (via `redact_sensitive_data()`). Aggressive find/replace on raw debug output ends up masking non-sensitive identifiers — entry IDs, container IDs, GCIDs — and makes diagnosis harder. Issue #377 hit exactly this: the user's redactor turned the integration's own entry ID into `[UNKNOWN_VIN]`, briefly suggesting a phantom second vehicle.

This PR rewrites the debug-logs description to:

- Tell users what the integration already redacts.
- Spell out what they still need to redact (account email, precise GPS coordinates, anything visible in screenshots).
- Ask them to leave internal identifiers visible.

Also folds in a separate small fix in the same description block: the example logger config pointed at `custom_components.bmw_cardata`, but the actual module is `custom_components.cardata`, so following the template's instructions verbatim never produced any debug output. Replaced with the correct module name.

YAML form schema validates.