### PR TITLE
soc: preserve sub-integer prediction across short charging pauses

### DIFF
--- a/.github/workflows/check-debug-logs.yml
+++ b/.github/workflows/check-debug-logs.yml
@@ -25,6 +25,12 @@ jobs:
             const match = body.match(/### Debug logs\s*\n([\s\S]*?)(?=\n### |$)/);
             const logsSection = match ? match[1].trim() : '';
 
+            // A .log attachment anywhere in the body counts as valid evidence —
+            // mirrors the comment job's behaviour so reports that link the file
+            // instead of pasting it don't get falsely flagged.
+            const logAttachmentPattern = /github\.com\/user-attachments\/files\/\d+\/[^\s)]+\.log\b/i;
+            const hasLogAttachment = logAttachmentPattern.test(body);
+
             // Must contain at least one DEBUG-level line in an actual log entry.
             // WARNING/INFO-only logs are not debug logs, and the word DEBUG
             // appearing in yaml snippets or instructions should not match.
@@ -38,7 +44,7 @@ jobs:
 
             const hasLabel = context.payload.issue.labels.some(l => l.name === 'needs-debug-logs');
             const matchCount = logPatterns.filter(p => p.test(logsSection)).length;
-            const isValid = logsSection.length > 100 && hasDebugLevel && matchCount >= 1;
+            const isValid = hasLogAttachment || (logsSection.length > 100 && hasDebugLevel && matchCount >= 1);
 
             if (!isValid) {
               // Add label if not present

--- a/custom_components/cardata/soc_prediction.py
+++ b/custom_components/cardata/soc_prediction.py
@@ -481,8 +481,11 @@ class SOCPredictor:
                     # Keep last_power_kw + reset gap to now for extrapolation continuity
                     self._derive_power_from_soc_change(vin, session, old_anchor, soc, ref_time)
         else:
-            # BEV not charging: snap to actual BMW SOC
-            self._last_predicted_soc[vin] = soc
+            # BEV not charging: BMW header reports integer SOC, so a sub-integer
+            # prediction within 0.5pp is still consistent with the same rounded
+            # value. Snapping would discard accuracy across short charging pauses.
+            if current_predicted is None or abs(current_predicted - soc) >= 0.5:
+                self._last_predicted_soc[vin] = soc
 
         # Try to finalize pending session if one exists
         self.try_finalize_pending_session(vin, soc, time.time())


### PR DESCRIPTION
When charging stops, the next BMW header (integer-rounded) overwrote our sub-integer prediction, losing accuracy on every solar-style on/off cycle. Keep predicted when within 0.5pp of BMW — same rule already used for the driving prediction in magic_soc.

NB: you really should make a new release, there are critical patches waiting.