### PR TITLE
magic_soc: preserve sub-integer prediction across charging pauses

### DIFF
--- a/custom_components/cardata/magic_soc.py
+++ b/custom_components/cardata/magic_soc.py
@@ -212,6 +212,14 @@ class MagicSOCPredictor:
         """Get last known battery capacity for fallback when descriptor evicted."""
         return self._last_known_capacity.get(vin)
 
+    def set_last_magic_soc(self, vin: str, soc: float) -> None:
+        """Record latest Magic SOC value so the not-charging snap-down has
+        a current reference. Used by soc_wiring during charging, when the
+        charging predictor owns the displayed value and get_magic_soc() is
+        bypassed.
+        """
+        self._last_magic_soc[vin] = soc
+
     # --- Persistence ---
 
     def get_session_data(self) -> dict[str, Any]:

--- a/custom_components/cardata/soc_wiring.py
+++ b/custom_components/cardata/soc_wiring.py
@@ -236,7 +236,10 @@ def get_magic_soc(
                 pass
 
     if is_charging:
-        return soc_predictor.get_predicted_soc(vin=vin, bmw_soc=bmw_soc)
+        predicted = soc_predictor.get_predicted_soc(vin=vin, bmw_soc=bmw_soc)
+        if predicted is not None:
+            magic_soc.set_last_magic_soc(vin, predicted)
+        return predicted
 
     mileage_state = vehicle_data.get(DESC_TRAVELLED_DISTANCE)
     mileage = None


### PR DESCRIPTION
During charging, soc_wiring.get_magic_soc() returns the charging predictor's value directly and bypasses magic_soc.get_magic_soc(), so _last_magic_soc[vin] was never refreshed. When charging stopped, the not-charging snap-down's 0.5pp guard compared BMW's integer SOC against a stale (pre-charge) cached value and snapped to BMW, dropping e.g. 54.4% to 54.0% on every pause. Resumption read the still-live charging predictor and resynced to 54.4%.

Mirror the displayed value into magic_soc._last_magic_soc via a new set_last_magic_soc() setter while charging, so the existing precision guard has a current reference and keeps the sub-integer prediction across pauses.

Refs kvanbiesen/bmw-cardata-ha#386.