### PR TITLE
Harden MQTT subscription handling and fix topic prefix help text

### DIFF
--- a/custom_components/cardata/stream.py
+++ b/custom_components/cardata/stream.py
@@ -550,7 +550,9 @@ class CardataStreamManager:
 
         if rc == 0:
             self._connection_state = ConnectionState.CONNECTED
-            self._circuit_breaker.record_success()
+            # Circuit breaker success is recorded on the SUBACK grant, not here.
+            # The broker can accept the connection and then refuse the
+            # subscription, which would leave us connected but receiving nothing.
             self._custom_auth_failures = 0
             self._custom_auth_retry_blocked = False
 
@@ -634,6 +636,32 @@ class CardataStreamManager:
                 )
 
     def _handle_subscribe(self, client: mqtt.Client, userdata, mid, granted_qos) -> None:
+        # granted_qos is a tuple of ints (paho VERSION1 callbacks, MQTT 3.1.1);
+        # a value of 0x80 means the broker refused that subscription. A refused
+        # SUBACK leaves the socket connected while no messages ever arrive, so
+        # treat it as a connection failure and reconnect instead of reporting
+        # the stream as healthy.
+        if any(getattr(qos, "value", qos) >= 0x80 for qos in granted_qos):
+            _LOGGER.warning(
+                "BMW MQTT subscription refused (mid=%s granted_qos=%s); reconnecting",
+                mid,
+                granted_qos,
+            )
+            self._connection_state = ConnectionState.FAILED
+            self._circuit_breaker.record_failure()
+            if self._status_callback:
+                self._run_coro_safe(
+                    cast(
+                        Coroutine[Any, Any, None],
+                        self._status_callback("connection_failed", "MQTT subscription refused"),
+                    )
+                )
+            self._safe_loop_stop(client)
+            self._client = None
+            stream_reconnect.schedule_retry(self, 3)
+            return
+
+        self._circuit_breaker.record_success()
         if debug_enabled():
             _LOGGER.debug("BMW MQTT subscribed mid=%s qos=%s", mid, granted_qos)
 

--- a/custom_components/cardata/translations/de.json
+++ b/custom_components/cardata/translations/de.json
@@ -65,7 +65,7 @@
           "custom_mqtt_username": "Leer lassen für anonymen Zugang.",
           "custom_mqtt_password": "Leer lassen für anonymen Zugang.",
           "custom_mqtt_tls": "Aus = unverschlüsselt (TCP), TLS = verifiziertes Zertifikat, TLS (selbstsigniert) = Zertifikatsprüfung überspringen.",
-          "custom_mqtt_topic_prefix": "Das Bridge-Topic-Präfix. Nachrichten werden unter {prefix}{vin} erwartet. Standard: bmw/"
+          "custom_mqtt_topic_prefix": "Das Bridge-Topic-Präfix. Nachrichten werden unter '{prefix}{vin}' erwartet. Standard: bmw/"
         }
       }
     },

--- a/custom_components/cardata/translations/en.json
+++ b/custom_components/cardata/translations/en.json
@@ -75,7 +75,7 @@
           "custom_mqtt_username": "Leave empty for anonymous access.",
           "custom_mqtt_password": "Leave empty for anonymous access.",
           "custom_mqtt_tls": "Off = plain TCP, TLS = verified certificate, TLS (self-signed) = skip certificate validation.",
-          "custom_mqtt_topic_prefix": "The bridge topic prefix. Messages are expected at {prefix}{vin}. Default: bmw/"
+          "custom_mqtt_topic_prefix": "The bridge topic prefix. Messages are expected at '{prefix}{vin}'. Default: bmw/"
         }
       }
     },

--- a/custom_components/cardata/translations/es.json
+++ b/custom_components/cardata/translations/es.json
@@ -65,7 +65,7 @@
           "custom_mqtt_username": "Dejar vacío para acceso anónimo.",
           "custom_mqtt_password": "Dejar vacío para acceso anónimo.",
           "custom_mqtt_tls": "Desactivado = TCP sin cifrar, TLS = certificado verificado, TLS (autofirmado) = omitir validación de certificado.",
-          "custom_mqtt_topic_prefix": "El prefijo de topic del bridge. Los mensajes se esperan en {prefix}{vin}. Predeterminado: bmw/"
+          "custom_mqtt_topic_prefix": "El prefijo de topic del bridge. Los mensajes se esperan en '{prefix}{vin}'. Predeterminado: bmw/"
         }
       }
     },

--- a/custom_components/cardata/translations/fr.json
+++ b/custom_components/cardata/translations/fr.json
@@ -65,7 +65,7 @@
           "custom_mqtt_username": "Laisser vide pour un accès anonyme.",
           "custom_mqtt_password": "Laisser vide pour un accès anonyme.",
           "custom_mqtt_tls": "Désactivé = TCP non chiffré, TLS = certificat vérifié, TLS (auto-signé) = ignorer la validation du certificat.",
-          "custom_mqtt_topic_prefix": "Le préfixe de topic du bridge. Les messages sont attendus à {prefix}{vin}. Par défaut : bmw/"
+          "custom_mqtt_topic_prefix": "Le préfixe de topic du bridge. Les messages sont attendus à '{prefix}{vin}'. Par défaut : bmw/"
         }
       }
     },

--- a/custom_components/cardata/translations/it.json
+++ b/custom_components/cardata/translations/it.json
@@ -65,7 +65,7 @@
           "custom_mqtt_username": "Lasciare vuoto per accesso anonimo.",
           "custom_mqtt_password": "Lasciare vuoto per accesso anonimo.",
           "custom_mqtt_tls": "Disattivato = TCP non crittografato, TLS = certificato verificato, TLS (autofirmato) = ignora la validazione del certificato.",
-          "custom_mqtt_topic_prefix": "Il prefisso topic del bridge. I messaggi sono attesi su {prefix}{vin}. Predefinito: bmw/"
+          "custom_mqtt_topic_prefix": "Il prefisso topic del bridge. I messaggi sono attesi su '{prefix}{vin}'. Predefinito: bmw/"
         }
       }
     },

--- a/custom_components/cardata/translations/nl.json
+++ b/custom_components/cardata/translations/nl.json
@@ -65,7 +65,7 @@
           "custom_mqtt_username": "Leeg laten voor anonieme toegang.",
           "custom_mqtt_password": "Leeg laten voor anonieme toegang.",
           "custom_mqtt_tls": "Uit = onversleuteld TCP, TLS = geverifieerd certificaat, TLS (zelfondertekend) = certificaatvalidatie overslaan.",
-          "custom_mqtt_topic_prefix": "Het bridge topic-prefix. Berichten worden verwacht op {prefix}{vin}. Standaard: bmw/"
+          "custom_mqtt_topic_prefix": "Het bridge topic-prefix. Berichten worden verwacht op '{prefix}{vin}'. Standaard: bmw/"
         }
       }
     },

--- a/custom_components/cardata/translations/pt.json
+++ b/custom_components/cardata/translations/pt.json
@@ -65,7 +65,7 @@
           "custom_mqtt_username": "Deixar vazio para acesso anónimo.",
           "custom_mqtt_password": "Deixar vazio para acesso anónimo.",
           "custom_mqtt_tls": "Desligado = TCP não encriptado, TLS = certificado verificado, TLS (autoassinado) = ignorar validação do certificado.",
-          "custom_mqtt_topic_prefix": "O prefixo de tópico do bridge. As mensagens são esperadas em {prefix}{vin}. Predefinido: bmw/"
+          "custom_mqtt_topic_prefix": "O prefixo de tópico do bridge. As mensagens são esperadas em '{prefix}{vin}'. Predefinido: bmw/"
         }
       }
     },


### PR DESCRIPTION
Two fixes that came out of investigating #395 (sensors that arrive only over MQTT, such as location, alarm and door state, frozen while the REST telematic poll keeps working).

### Detect a refused MQTT subscription
The circuit breaker recorded a successful connection in `on_connect`, before the SUBACK arrived. A broker that accepts the connection but refuses the subscription therefore left the stream reporting "connected" while no messages ever arrived, with no reconnect and no visible error. Success is now recorded on the SUBACK grant, and a refused subscription (return code `0x80`) is treated as a connection failure: it logs a warning, sets the stream status to failed, and reconnects through the existing backoff.

### Escape braces in the custom MQTT topic prefix help text
The description for the topic prefix field contained a literal `{prefix}{vin}`. Home Assistant runs option descriptions through ICU message formatting, which read those as variables and raised a `MISSING_VALUE` error, so the help text failed to render on the MQTT broker options step (visible in the logs on #395). The placeholders are now single-quoted so they display literally, across all seven locales.

Both changes pass ruff and mypy. The subscription handling was verified against granted, refused and mixed SUBACK responses.