### PR TITLE
Stop evicting non-PRIMARY vehicles on every restart

### DIFF
--- a/custom_components/cardata/coordinator.py
+++ b/custom_components/cardata/coordinator.py
@@ -41,6 +41,7 @@ from homeassistant.helpers.entity_registry import async_get as async_get_entity_
 from homeassistant.helpers.event import async_call_later
 
 from .const import (
+    ALLOWED_VINS_KEY,
     DIAGNOSTIC_LOG_INTERVAL,
     DOMAIN,
     LOCATION_LATITUDE_DESCRIPTOR,
@@ -77,7 +78,7 @@ from .soc_wiring import (
     process_soc_descriptors,
 )
 from .units import normalize_unit
-from .utils import get_all_registered_vins, is_valid_vin, redact_vin
+from .utils import get_externally_owned_vins, is_valid_vin, redact_vin
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -560,7 +561,7 @@ class CardataCoordinator:
                 len(self._allowed_vins),
                 self.entry_id,
             )
-            other_vins = get_all_registered_vins(self.hass, exclude_entry_id=self.entry_id)
+            other_vins = get_externally_owned_vins(self.hass, exclude_entry_id=self.entry_id)
             _LOGGER.debug(
                 "MQTT VIN dedup: other entries own %d VIN(s): %s",
                 len(other_vins),
@@ -579,6 +580,27 @@ class CardataCoordinator:
                 self.entry_id,
                 len(self._allowed_vins),
             )
+
+            # Persist the claim so it survives restart. Without this, the restore
+            # logic in lifecycle evicted the device for this VIN on every HA start
+            # because entry.data still held the pre-claim allowed list (issue #402).
+            # Function-level import: runtime.py imports coordinator.py at module
+            # level, so a top-level import here would be circular.
+            from .runtime import async_update_entry_data
+
+            entry = self.hass.config_entries.async_get_entry(self.entry_id)
+            if entry is not None:
+                await async_update_entry_data(self.hass, entry, {ALLOWED_VINS_KEY: sorted(self._allowed_vins)})
+                _LOGGER.debug(
+                    "Persisted dynamically claimed VIN %s to entry data",
+                    redact_vin(vin),
+                )
+            else:
+                _LOGGER.debug(
+                    "Entry %s not found; claim for VIN %s kept in-memory only",
+                    self.entry_id,
+                    redact_vin(vin),
+                )
 
         if len(data) > self._MAX_DESCRIPTORS_PER_VIN:
             _LOGGER.warning(

--- a/custom_components/cardata/lifecycle.py
+++ b/custom_components/cardata/lifecycle.py
@@ -87,11 +87,18 @@ from .debug import set_debug_enabled
 from .device_flow import CardataAuthError
 from .frontend_cards import async_setup_frontend_cards, async_unload_frontend_cards_if_last_entry
 from .metadata import async_restore_vehicle_images, async_restore_vehicle_metadata
-from .runtime import CardataRuntimeData, cleanup_entry_lock
+from .runtime import CardataRuntimeData, async_update_entry_data, cleanup_entry_lock
 from .services import async_register_services, async_unregister_services
 from .stream import CardataStreamManager
 from .telematics import async_telematic_poll_loop
-from .utils import async_cancel_task, redact_vin, redact_vins, validate_and_clamp_option
+from .utils import (
+    async_cancel_task,
+    get_externally_owned_vins,
+    partition_restored_vins,
+    redact_vin,
+    redact_vins,
+    validate_and_clamp_option,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -293,17 +300,24 @@ async def async_setup_cardata(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 entry.entry_id,
             )
 
-            # Clean up device_metadata, names, and devices for VINs not in allowed list
-            # This is needed because async_restore_vehicle_metadata creates devices for
-            # ALL VINs in stored metadata before we know which VINs are allowed
-            # Note: We always run this cleanup when allowed_vins key exists, even if empty
-            # An empty allowed list means this entry owns no VINs, so remove ALL VINs
+            # Reconcile restored metadata VINs against the allowed list. Metadata VINs
+            # missing from the allowed list are either duplicates owned by another
+            # config entry (remove them - existing cross-entry dedup behavior) or
+            # orphans owned by nobody, e.g. a non-PRIMARY mapped vehicle that was
+            # dynamically claimed from MQTT but whose claim predates persistence.
+            # Orphans are adopted instead of destroyed; blindly removing them evicted
+            # the vehicle's device and entities on every restart (issue #402).
+            # Ownership must consider the PERSISTED allowed lists of other entries
+            # too, because entry load order at startup is nondeterministic.
             from homeassistant.helpers import device_registry as dr
 
             device_registry = dr.async_get(hass)
-            vins_to_remove = [
-                vin for vin in list(coordinator.device_metadata.keys()) if vin not in coordinator._allowed_vins
-            ]
+            externally_owned = get_externally_owned_vins(hass, exclude_entry_id=entry.entry_id)
+            vins_to_remove, vins_to_adopt = partition_restored_vins(
+                list(coordinator.device_metadata.keys()),
+                coordinator._allowed_vins,
+                externally_owned,
+            )
             for vin in vins_to_remove:
                 coordinator.device_metadata.pop(vin, None)
                 coordinator.names.pop(vin, None)
@@ -313,14 +327,23 @@ async def async_setup_cardata(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 if device and entry.entry_id in device.config_entries:
                     device_registry.async_remove_device(device.id)
                     _LOGGER.info(
-                        "Removed device for VIN %s (not in allowed list for this entry)",
+                        "Removed device for VIN %s (owned by another config entry)",
                         redact_vin(vin),
                     )
                 else:
                     _LOGGER.debug(
-                        "Removed VIN %s from coordinator (not in allowed list for this entry)",
+                        "Removed VIN %s from coordinator (owned by another config entry)",
                         redact_vin(vin),
                     )
+            if vins_to_adopt:
+                coordinator._allowed_vins.update(vins_to_adopt)
+                for vin in vins_to_adopt:
+                    _LOGGER.info(
+                        "Adopting VIN %s into allowed list (present in this entry's metadata, "
+                        "not owned by any other entry)",
+                        redact_vin(vin),
+                    )
+                await async_update_entry_data(hass, entry, {ALLOWED_VINS_KEY: sorted(coordinator._allowed_vins)})
         else:
             _LOGGER.warning(
                 "No allowed VINs key in entry data for entry %s - will force bootstrap to run",

--- a/custom_components/cardata/utils.py
+++ b/custom_components/cardata/utils.py
@@ -261,3 +261,66 @@ def get_all_registered_vins(
         [redact_vin(v) for v in all_vins],
     )
     return all_vins
+
+
+def get_externally_owned_vins(
+    hass: Any,
+    exclude_entry_id: str | None = None,
+) -> set[str]:
+    """Collect VINs owned by other config entries, loaded or not.
+
+    Extends get_all_registered_vins (which only sees the in-memory allowed VINs
+    of currently loaded entries) with the persisted allowed_vins lists of every
+    other config entry. The persisted half matters during startup: entry load
+    order is nondeterministic, so a VIN owned by a not-yet-loaded entry would
+    otherwise look unowned and could be wrongly claimed or adopted.
+
+    Args:
+        hass: Home Assistant instance
+        exclude_entry_id: Entry ID to exclude from the search (typically the current entry)
+
+    Returns:
+        Set of VINs owned by other config entries (in-memory or persisted)
+    """
+    from .const import ALLOWED_VINS_KEY, DOMAIN
+
+    all_vins = get_all_registered_vins(hass, exclude_entry_id=exclude_entry_id)
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        if entry.entry_id == exclude_entry_id:
+            continue
+        stored = entry.data.get(ALLOWED_VINS_KEY)
+        if isinstance(stored, list):
+            all_vins.update(vin for vin in stored if isinstance(vin, str))
+    _LOGGER.debug(
+        "VIN dedup: %d externally owned VIN(s) including persisted lists: %s",
+        len(all_vins),
+        [redact_vin(v) for v in all_vins],
+    )
+    return all_vins
+
+
+def partition_restored_vins(
+    metadata_vins: Iterable[str],
+    allowed_vins: set[str],
+    externally_owned_vins: set[str],
+) -> tuple[list[str], list[str]]:
+    """Split restored-metadata VINs missing from this entry's allowed list.
+
+    Returns (vins_to_remove, vins_to_adopt):
+    - vins_to_remove: owned by another config entry -> duplicates, remove them
+      (existing cross-entry dedup behavior).
+    - vins_to_adopt: owned by nobody -> re-adopt into this entry's allowed list.
+      This self-heals entries whose VIN was dynamically claimed from MQTT (e.g.
+      a non-PRIMARY mapped vehicle) but whose claim was never persisted, which
+      previously caused the device to be evicted on every restart (issue #402).
+    """
+    vins_to_remove: list[str] = []
+    vins_to_adopt: list[str] = []
+    for vin in metadata_vins:
+        if vin in allowed_vins:
+            continue
+        if vin in externally_owned_vins:
+            vins_to_remove.append(vin)
+        else:
+            vins_to_adopt.append(vin)
+    return vins_to_remove, vins_to_adopt

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -26,10 +26,11 @@
 """Tests for the coordinator module, focusing on message handling and motion detection."""
 
 from datetime import UTC, datetime, timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from custom_components.cardata.const import ALLOWED_VINS_KEY, DOMAIN
 from custom_components.cardata.coordinator import CardataCoordinator
 
 
@@ -191,3 +192,89 @@ class TestDerivedMotion:
         result = coordinator.get_derived_is_moving(vin)
 
         assert result is False
+
+
+class TestDynamicVinClaim:
+    """Tests for dynamic VIN claiming and claim persistence (issue #402)."""
+
+    OWNED_VIN = "WBY00000000006306"
+    NEW_VIN = "WBA00000000008448"
+
+    @pytest.fixture
+    def mock_hass(self):
+        """Create a mock Home Assistant instance with empty domain/entry state."""
+        hass = MagicMock()
+        hass.loop = MagicMock()
+        hass.bus = MagicMock()
+        hass.bus.async_fire = MagicMock()
+        hass.data = {DOMAIN: {}}
+        hass.config_entries.async_entries.return_value = []
+        return hass
+
+    @pytest.fixture
+    def coordinator(self, mock_hass):
+        """Create a coordinator that already owns one VIN."""
+        with patch("custom_components.cardata.coordinator.async_dispatcher_send"):
+            coord = CardataCoordinator(mock_hass, "test_entry_id")
+        coord._allowed_vins = {self.OWNED_VIN}
+        coord._allowed_vins_initialized = True
+        return coord
+
+    def _payload(self):
+        return {
+            "vin": self.NEW_VIN,
+            "data": {"vehicle.speed": {"value": 100, "unit": "km/h", "timestamp": None}},
+        }
+
+    @pytest.mark.asyncio
+    async def test_dynamic_claim_persists_to_entry_data(self, coordinator, mock_hass):
+        """A dynamically claimed VIN is written back to entry data."""
+        entry = MagicMock()
+        mock_hass.config_entries.async_get_entry.return_value = entry
+
+        with patch(
+            "custom_components.cardata.runtime.async_update_entry_data",
+            new_callable=AsyncMock,
+        ) as persist:
+            await coordinator.async_handle_message(self._payload())
+
+        persist.assert_awaited_once_with(
+            mock_hass,
+            entry,
+            {ALLOWED_VINS_KEY: sorted({self.OWNED_VIN, self.NEW_VIN})},
+        )
+        assert self.NEW_VIN in coordinator._allowed_vins
+        assert self.NEW_VIN in coordinator.data
+
+    @pytest.mark.asyncio
+    async def test_claim_rejected_when_vin_persisted_by_other_entry(self, coordinator, mock_hass):
+        """A VIN in another entry's persisted allowed list is not claimed."""
+        other_entry = MagicMock()
+        other_entry.entry_id = "other_entry_id"
+        other_entry.data = {ALLOWED_VINS_KEY: [self.NEW_VIN]}
+        mock_hass.config_entries.async_entries.return_value = [other_entry]
+
+        with patch(
+            "custom_components.cardata.runtime.async_update_entry_data",
+            new_callable=AsyncMock,
+        ) as persist:
+            await coordinator.async_handle_message(self._payload())
+
+        persist.assert_not_awaited()
+        assert self.NEW_VIN not in coordinator._allowed_vins
+        assert self.NEW_VIN not in coordinator.data
+
+    @pytest.mark.asyncio
+    async def test_claim_survives_missing_entry(self, coordinator, mock_hass):
+        """If the config entry cannot be resolved, the claim stays in-memory only."""
+        mock_hass.config_entries.async_get_entry.return_value = None
+
+        with patch(
+            "custom_components.cardata.runtime.async_update_entry_data",
+            new_callable=AsyncMock,
+        ) as persist:
+            await coordinator.async_handle_message(self._payload())
+
+        persist.assert_not_awaited()
+        assert self.NEW_VIN in coordinator._allowed_vins
+        assert self.NEW_VIN in coordinator.data

--- a/tests/test_vin_ownership.py
+++ b/tests/test_vin_ownership.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2025, Renaud Allard <renaud@allard.it>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for cross-entry VIN ownership helpers (issue #402)."""
+
+from unittest.mock import MagicMock
+
+from custom_components.cardata.const import ALLOWED_VINS_KEY, DOMAIN
+from custom_components.cardata.utils import (
+    get_externally_owned_vins,
+    partition_restored_vins,
+)
+
+VIN_A = "WBY00000000006306"
+VIN_B = "WBA00000000008448"
+
+
+class TestPartitionRestoredVins:
+    """Tests for the restore-time remove/adopt decision."""
+
+    def test_adopts_orphan_vin(self):
+        """A metadata VIN owned by nobody is adopted, not removed (issue #402)."""
+        to_remove, to_adopt = partition_restored_vins([VIN_A, VIN_B], {VIN_A}, set())
+        assert to_remove == []
+        assert to_adopt == [VIN_B]
+
+    def test_removes_externally_owned_vin(self):
+        """A metadata VIN owned by another entry is removed (dedup behavior)."""
+        to_remove, to_adopt = partition_restored_vins([VIN_A, VIN_B], {VIN_A}, {VIN_B})
+        assert to_remove == [VIN_B]
+        assert to_adopt == []
+
+    def test_empty_allowed_list_externally_owned(self):
+        """Empty allowed list + VIN owned elsewhere: still removed (dedup state preserved)."""
+        to_remove, to_adopt = partition_restored_vins([VIN_A], set(), {VIN_A})
+        assert to_remove == [VIN_A]
+        assert to_adopt == []
+
+    def test_empty_allowed_list_orphan(self):
+        """Empty allowed list + orphan metadata VIN: adopted (self-heal)."""
+        to_remove, to_adopt = partition_restored_vins([VIN_A], set(), set())
+        assert to_remove == []
+        assert to_adopt == [VIN_A]
+
+    def test_allowed_vins_untouched(self):
+        """VINs already in the allowed list are neither removed nor adopted."""
+        to_remove, to_adopt = partition_restored_vins([VIN_A], {VIN_A}, {VIN_A})
+        assert to_remove == []
+        assert to_adopt == []
+
+
+class TestGetExternallyOwnedVins:
+    """Tests for ownership collection across loaded and unloaded entries."""
+
+    def _make_entry(self, entry_id, data):
+        entry = MagicMock()
+        entry.entry_id = entry_id
+        entry.data = data
+        return entry
+
+    def _make_hass(self, domain_data, entries):
+        hass = MagicMock()
+        hass.data = {DOMAIN: domain_data}
+        hass.config_entries.async_entries.return_value = entries
+        return hass
+
+    def test_merges_loaded_and_persisted(self):
+        """In-memory VINs of loaded entries merge with persisted lists of others."""
+        runtime = MagicMock()
+        runtime.coordinator._allowed_vins = {VIN_A}
+        persisted_entry = self._make_entry("unloaded_entry", {ALLOWED_VINS_KEY: [VIN_B]})
+        hass = self._make_hass({"loaded_entry": runtime}, [persisted_entry])
+
+        assert get_externally_owned_vins(hass, exclude_entry_id="my_entry") == {VIN_A, VIN_B}
+
+    def test_excludes_own_entry(self):
+        """The current entry's own VINs are not reported as externally owned."""
+        runtime = MagicMock()
+        runtime.coordinator._allowed_vins = {VIN_A}
+        own_entry = self._make_entry("my_entry", {ALLOWED_VINS_KEY: [VIN_A]})
+        hass = self._make_hass({"my_entry": runtime}, [own_entry])
+
+        assert get_externally_owned_vins(hass, exclude_entry_id="my_entry") == set()
+
+    def test_ignores_missing_or_invalid_persisted_data(self):
+        """Entries without the key or with non-list values are ignored."""
+        no_key = self._make_entry("entry1", {})
+        bad_type = self._make_entry("entry2", {ALLOWED_VINS_KEY: "not-a-list"})
+        mixed = self._make_entry("entry3", {ALLOWED_VINS_KEY: [VIN_B, 123, None]})
+        hass = self._make_hass({}, [no_key, bad_type, mixed])
+
+        assert get_externally_owned_vins(hass, exclude_entry_id="my_entry") == {VIN_B}


### PR DESCRIPTION
Fixes #402.

## Problem

With two cars on one BMW account where one is **not** a `PRIMARY` mapping, the non-primary car's device and all its entities were removed on every Home Assistant restart, then only partially rebuilt when the car next streamed (missing all descriptors that don't re-stream while idle, with entity-ID churn breaking automations).

Root cause: bootstrap persists only PRIMARY-mapped VINs to `entry.data[allowed_vins]` and never re-runs. On each restart, the lifecycle restore logic deleted the device for any metadata VIN missing from that stale list. The coordinator *did* dynamically re-claim the VIN when its MQTT data arrived — but the claim was in-memory only, so the persisted list never changed and the eviction repeated forever.

## Changes

1. **Persist dynamic VIN claims** (`coordinator.py`). When `async_handle_message` dynamically claims a VIN, the merged allowed list is now written back to entry data via the existing `async_update_entry_data` helper (function-level import to avoid the `runtime` ↔ `coordinator` circular import, same pattern as `stream.py`).

2. **Non-destructive restart cleanup + self-heal** (`lifecycle.py`, `utils.py`). Restored metadata VINs missing from the allowed list are now only removed when they are *actually owned by another config entry* (the cross-entry dedup case is fully preserved). Orphaned VINs owned by nobody are adopted back into the allowed list and persisted — installs already broken by this bug self-heal on the first startup after upgrading, before platform setup, so the full entity set is restored with stable entity IDs.

3. **Ownership checks see unloaded entries** (`utils.py`). New `get_externally_owned_vins()` unions the in-memory allowed VINs of loaded entries with the *persisted* `allowed_vins` of all other config entries, since entry load order at startup is nondeterministic. Used by both the lifecycle reconciliation and the dynamic-claim check, so a claim can't steal a VIN from an entry that just hasn't loaded yet.

## Deliberately unchanged

- The PRIMARY filter in bootstrap (`extract_primary_vins`) and all REST polling behavior are untouched. Widening discovery to SECONDARY mappings is a possible follow-up.
- **No new API quota usage**: telematics polling already selects VINs from `coordinator.data` (filled by MQTT), not from `_allowed_vins`, so a dynamically claimed non-primary vehicle was already being polled today — and the poll budget is total-capped, not per-VIN additive.
- Sold/removed vehicles behave exactly as PRIMARY cars do today (the allowed list was never re-derived for them either); manual device deletion and "Clean up orphaned entities" remain the remedy.

## Testing

- 11 new tests: `tests/test_vin_ownership.py` (remove/adopt partition logic incl. empty-list and dedup edge cases; ownership merging across loaded + persisted entries) and `TestDynamicVinClaim` in `tests/test_coordinator.py` (claim persists to entry data; claim rejected when another entry's persisted list owns the VIN; graceful no-persist when the entry can't be resolved).
- `ruff check`, `ruff format --check`, `flake8`, and `mypy` all clean with the repo's CI settings.
- **Verified live** on the issue-#402 setup (i4 PRIMARY + iX3 non-primary on one account): after upgrading, the startup log shows the iX3 being adopted into the allowed list, the device survives restarts with its full entity set, and `allowed_vins` in `.storage/core.config_entries` now contains both VINs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J91pZZZya1TSmmcGUax7wR