### PR TITLE
Add configurable mini map height to the vehicle card

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Available configuration options:
 | `show_range` | `true` | Battery / fuel level bar with range |
 | `show_image` | `true` | Vehicle image |
 | `show_map` | `true` | Inline location map |
+| `map_height` | `120` | Mini map height in pixels |
 | `show_buttons` | `true` | Quick-info tiles (location, mileage, service) |
 
 ### YAML Configuration
@@ -276,6 +277,7 @@ show_indicators: true
 show_range: true
 show_image: true
 show_map: true
+map_height: 120
 show_buttons: true
 ```
 

--- a/custom_components/cardata/frontend/bmw-cardata-vehicle-card.js
+++ b/custom_components/cardata/frontend/bmw-cardata-vehicle-card.js
@@ -8,6 +8,8 @@
 const WS_TYPE = "cardata/vehicle_cards";
 const CARD_TAG = "bmw-cardata-vehicle-card";
 const CACHE_MS = 30_000;
+const CARD_SIZE_UNIT_PX = 50;
+const MAP_HEIGHT_DEFAULT = 120;
 
 const ensureCustomCardsArray = () => {
   window.customCards = window.customCards || [];
@@ -43,6 +45,11 @@ const toNumberOrZero = (stateObj) => {
 };
 
 const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+
+const mapHeightConfig = (cfg) => {
+  const value = Number(cfg?.map_height);
+  return Number.isFinite(value) && value > 0 ? value : MAP_HEIGHT_DEFAULT;
+};
 
 const isOpenState = (stateObj) => {
   const state = normalizeState(stateObj);
@@ -139,7 +146,7 @@ class BmwCardataVehicleCard extends HTMLElement {
     const cfg = this._config || {};
     let size = 5;
     if (boolConfig(cfg, "show_image", true)) size += 2;
-    if (boolConfig(cfg, "show_map", true)) size += 2;
+    if (boolConfig(cfg, "show_map", true)) size += mapHeightConfig(cfg) / CARD_SIZE_UNIT_PX;
     if (boolConfig(cfg, "show_buttons", true)) size += 2;
     return size;
   }
@@ -172,6 +179,15 @@ class BmwCardataVehicleCard extends HTMLElement {
         { name: "show_range", selector: { boolean: {} } },
         { name: "show_image", selector: { boolean: {} } },
         { name: "show_map", selector: { boolean: {} } },
+        {
+          name: "map_height",
+          selector: {
+            number: {
+              mode: "box",
+              unit_of_measurement: "px",
+            },
+          },
+        },
         { name: "show_buttons", selector: { boolean: {} } },
       ],
       computeLabel: (schema) => {
@@ -182,6 +198,7 @@ class BmwCardataVehicleCard extends HTMLElement {
         if (schema.name === "show_range") return "Show SOC and range bar";
         if (schema.name === "show_image") return "Show vehicle image";
         if (schema.name === "show_map") return "Show mini map";
+        if (schema.name === "map_height") return "Mini map height";
         if (schema.name === "show_buttons") return "Show quick info buttons";
         return undefined;
       },
@@ -195,6 +212,7 @@ class BmwCardataVehicleCard extends HTMLElement {
       show_range: true,
       show_image: true,
       show_map: true,
+      map_height: MAP_HEIGHT_DEFAULT,
       show_buttons: true,
     };
   }
@@ -441,17 +459,17 @@ class BmwCardataVehicleCard extends HTMLElement {
           .map hui-map-card {
             display: block;
             width: 100%;
-            height: 120px;
+            height: var(--map-height, ${MAP_HEIGHT_DEFAULT}px);
           }
           .map-mount {
-            height: 120px;
+            height: var(--map-height, ${MAP_HEIGHT_DEFAULT}px);
             overflow: hidden;
           }
           .map-mount > * {
             height: 100%;
           }
           .map-fallback {
-            height: 120px;
+            height: var(--map-height, ${MAP_HEIGHT_DEFAULT}px);
             display: flex;
             align-items: center;
             justify-content: center;
@@ -624,8 +642,8 @@ class BmwCardataVehicleCard extends HTMLElement {
         entities: [trackerEntityId],
         default_zoom: 14,
         hours_to_show: 24,
-        aspect_ratio: "16:6",
       });
+      mapCard.layout = "grid";
       mapCard.hass = hass;
       return mapCard;
     } catch {
@@ -739,6 +757,8 @@ class BmwCardataVehicleCard extends HTMLElement {
     const showMap = boolConfig(cfg, "show_map", true);
     const showButtons = boolConfig(cfg, "show_buttons", true);
     const mapEntityId = entities.device_tracker;
+
+    mapEl.style.setProperty("--map-height", `${mapHeightConfig(cfg)}px`);
 
     const lockState = normalizeState(read("doors_lock"));
     const doorsOverallStateObj = read("doors_overall");


### PR DESCRIPTION
Adds a `map_height` option to the card to change the height of the mini map, with a default of `120px`.

<img width="535" height="552" alt="120px" src="https://github.com/user-attachments/assets/aaf9fdca-e689-4fb3-9934-ef33fe70c330" />

<img width="535" height="814" alt="360px" src="https://github.com/user-attachments/assets/4cfbda77-a28a-45b0-af66-3800433755f7" />
