### PR TITLE
Repair the nightly fuzzing so that it can report a failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,3 +90,36 @@ jobs:
 
       - name: Compile all
         run: python -m compileall custom_components/cardata
+
+  fuzz-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v5
+
+      # Pinned to 3.11 to match the fuzzing workflow: atheris has no wheel for
+      # 3.13, so the version the other jobs use cannot install it.
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: requirements-fuzz.txt
+
+      - name: Install fuzzing dependencies
+        run: pip install -r requirements-fuzz.txt
+
+      # The nightly fuzzing only notices a broken harness at 01:00, and a
+      # harness that dies at import wastes a whole matrix job. Import each one
+      # here instead. The glob must match the one the fuzzing workflow uses to
+      # build its matrix. run_name keeps main() from starting a real fuzz run,
+      # and each harness needs its own process because the homeassistant stub
+      # installers skip their work when the module is already imported.
+      - name: Import every fuzz harness
+        run: |
+          status=0
+          for harness in fuzz/fuzz_*.py; do
+            echo "== $harness"
+            python -c "import runpy, sys; runpy.run_path(sys.argv[1], run_name='smoke')" "$harness" || status=1
+          done
+          exit $status

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -209,26 +209,47 @@ jobs:
               { owner, repo, run_id: runId, per_page: 100 }
             );
 
-            // Distinguish a fuzzer-found crash (Run fuzzer step completed with
-            // a non-zero exit code) from a runner kill (the step never
-            // completed because the runner was terminated externally — OOM,
-            // infrastructure issue, etc.). The latter is infrastructure noise,
-            // not a code bug, so it should not file an issue.
+            // Classify each failed matrix job by what its "Run fuzzer" step did.
+            //
+            //   crashed  the step ran and exited non-zero, so the fuzzer found
+            //            something (or the harness itself is broken)
+            //   broken   the step was skipped because an earlier step failed,
+            //            so no fuzzing happened at all
+            //   killed   the step never completed, or the job carries no steps,
+            //            which is what a lost or cancelled runner looks like
+            //
+            // Only the first two are worth an issue. A lost runner is noise
+            // from outside the repository. If nothing classifies at all we
+            // still file, so a job rename can never silence this quietly.
             const crashedJobs = [];
+            const brokenJobs = [];
             const killedJobs = [];
             for (const job of jobs) {
+              if (!job.name.startsWith("fuzz (")) continue;
               if (job.conclusion !== "failure" && job.conclusion !== "cancelled") continue;
-              const runFuzzer = (job.steps || []).find((s) => s.name === "Run fuzzer");
-              if (runFuzzer && runFuzzer.status !== "completed") {
+              const steps = job.steps || [];
+              const runFuzzer = steps.find((s) => s.name === "Run fuzzer");
+              if (!runFuzzer || runFuzzer.status !== "completed") {
                 killedJobs.push(job.name);
-              } else {
+                continue;
+              }
+              if (runFuzzer.conclusion === "failure") {
                 crashedJobs.push(job.name);
+                continue;
+              }
+              const failedStep = steps.find(
+                (s) => s.name !== "Run fuzzer" && s.conclusion === "failure"
+              );
+              if (failedStep) {
+                brokenJobs.push(`${job.name} (failed at "${failedStep.name}")`);
+              } else {
+                killedJobs.push(job.name);
               }
             }
 
-            if (crashedJobs.length === 0 && killedJobs.length > 0) {
+            if (crashedJobs.length === 0 && brokenJobs.length === 0 && killedJobs.length > 0) {
               core.notice(
-                `Skipping issue creation: ${killedJobs.length} job(s) were terminated externally (likely runner kill), no fuzzer crashes detected. Killed: ${killedJobs.join(", ")}`
+                `Skipping issue creation: ${killedJobs.length} job(s) never completed the Run fuzzer step (lost or cancelled runner). Affected: ${killedJobs.join(", ")}`
               );
               return;
             }
@@ -237,12 +258,21 @@ jobs:
               "Automated report: the scheduled fuzzing workflow failed.",
               "",
               `Run: ${runUrl}`,
-              "",
-              "Crashed jobs (fuzzer found a real failure):",
-              crashedJobs.length
-                ? crashedJobs.map((n) => `- ${n}`).join("\n")
-                : "- (none)",
             ];
+            if (crashedJobs.length) {
+              sections.push(
+                "",
+                "Crashed jobs (the fuzzer found a failure):",
+                crashedJobs.map((n) => `- ${n}`).join("\n")
+              );
+            }
+            if (brokenJobs.length) {
+              sections.push(
+                "",
+                "Broken jobs (CI setup failed, the fuzzer never ran):",
+                brokenJobs.map((n) => `- ${n}`).join("\n")
+              );
+            }
             if (killedJobs.length) {
               sections.push(
                 "",

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -55,16 +55,29 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-fuzz.txt
 
+      # Caches are immutable, so the key has to be unique per run and the
+      # rolling prefix in restore-keys is what actually finds last night's
+      # corpus. restore and save are used separately because the combined
+      # action skips its save step unless the job succeeded, which would throw
+      # away the corpus on exactly the night a fuzzer crashes.
+      - name: Restore corpus
+        uses: actions/cache/restore@v6
+        with:
+          path: corpus
+          key: fuzz-corpus-${{ matrix.fuzzer }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: fuzz-corpus-${{ matrix.fuzzer }}-
+
       - name: Run fuzzer
         run: |
           set -o pipefail
           # libFuzzer treats a prefix ending in a separator as a directory and
-          # refuses to start if it is missing, so create it first.
-          mkdir -p crashes
+          # refuses to start if it is missing, and the corpus directory is not
+          # created by a cache miss, so create both first.
+          mkdir -p corpus crashes
           # Stream stdout to the action log (visible) and keep only the last
           # ~5000 lines on disk (capturing libFuzzer's crash dump tail without
           # letting the file grow unbounded over a 5h run).
-          python fuzz/${{ matrix.fuzzer }} -artifact_prefix=crashes/ -max_total_time=18000 -timeout=30 2>&1 \
+          python fuzz/${{ matrix.fuzzer }} -artifact_prefix=crashes/ -max_total_time=18000 -timeout=30 corpus 2>&1 \
             | python3 -u -c "
           import sys
           from collections import deque
@@ -76,6 +89,13 @@ jobs:
           with open('fuzz_output.txt', 'w') as f:
               f.writelines(buf)
           "
+
+      - name: Save corpus
+        if: always()
+        uses: actions/cache/save@v6
+        with:
+          path: corpus
+          key: fuzz-corpus-${{ matrix.fuzzer }}-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Upload crashing inputs
         if: failure()
@@ -160,7 +180,7 @@ jobs:
           PY
         env:
           FUZZER_NAME: ${{ matrix.fuzzer }}
-          FUZZER_COMMAND: python fuzz/${{ matrix.fuzzer }} -artifact_prefix=crashes/ -max_total_time=18000 -timeout=30
+          FUZZER_COMMAND: python fuzz/${{ matrix.fuzzer }} -artifact_prefix=crashes/ -max_total_time=18000 -timeout=30 corpus
           FUZZER_SNIPPET: fuzz_failure_${{ matrix.fuzzer }}.txt
 
       - name: Upload failure snippet

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -56,8 +56,6 @@ jobs:
           pip install -r requirements-fuzz.txt
 
       - name: Run fuzzer
-        id: run_fuzzer
-        continue-on-error: true
         run: |
           set -o pipefail
           # Stream stdout to the action log (visible) and keep only the last
@@ -75,12 +73,9 @@ jobs:
           with open('fuzz_output.txt', 'w') as f:
               f.writelines(buf)
           "
-          exit_code=${PIPESTATUS[0]}
-          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
-          exit 0
 
       - name: Extract failure snippet
-        if: ${{ steps.run_fuzzer.outputs.exit_code != '0' }}
+        if: failure()
         run: |
           python - <<'PY'
           import os
@@ -158,15 +153,11 @@ jobs:
           FUZZER_SNIPPET: fuzz_failure_${{ matrix.fuzzer }}.txt
 
       - name: Upload failure snippet
-        if: ${{ steps.run_fuzzer.outputs.exit_code != '0' }}
+        if: failure()
         uses: actions/upload-artifact@v6
         with:
           name: fuzz-failure-${{ matrix.fuzzer }}
           path: fuzz_failure_${{ matrix.fuzzer }}.txt
-
-      - name: Fail job if fuzzer failed
-        if: ${{ steps.run_fuzzer.outputs.exit_code != '0' }}
-        run: exit 1
 
   report_failure:
     needs: fuzz

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -58,10 +58,13 @@ jobs:
       - name: Run fuzzer
         run: |
           set -o pipefail
+          # libFuzzer treats a prefix ending in a separator as a directory and
+          # refuses to start if it is missing, so create it first.
+          mkdir -p crashes
           # Stream stdout to the action log (visible) and keep only the last
           # ~5000 lines on disk (capturing libFuzzer's crash dump tail without
           # letting the file grow unbounded over a 5h run).
-          python fuzz/${{ matrix.fuzzer }} -max_total_time=18000 -timeout=30 2>&1 \
+          python fuzz/${{ matrix.fuzzer }} -artifact_prefix=crashes/ -max_total_time=18000 -timeout=30 2>&1 \
             | python3 -u -c "
           import sys
           from collections import deque
@@ -73,6 +76,14 @@ jobs:
           with open('fuzz_output.txt', 'w') as f:
               f.writelines(buf)
           "
+
+      - name: Upload crashing inputs
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: fuzz-crash-${{ matrix.fuzzer }}
+          path: crashes/
+          if-no-files-found: ignore
 
       - name: Extract failure snippet
         if: failure()
@@ -149,7 +160,7 @@ jobs:
           PY
         env:
           FUZZER_NAME: ${{ matrix.fuzzer }}
-          FUZZER_COMMAND: python fuzz/${{ matrix.fuzzer }} -max_total_time=18000 -timeout=30
+          FUZZER_COMMAND: python fuzz/${{ matrix.fuzzer }} -artifact_prefix=crashes/ -max_total_time=18000 -timeout=30
           FUZZER_SNIPPET: fuzz_failure_${{ matrix.fuzzer }}.txt
 
       - name: Upload failure snippet
@@ -263,7 +274,9 @@ jobs:
               sections.push(
                 "",
                 "Crashed jobs (the fuzzer found a failure):",
-                crashedJobs.map((n) => `- ${n}`).join("\n")
+                crashedJobs.map((n) => `- ${n}`).join("\n"),
+                "",
+                "The crashing input is attached to the run as a fuzz-crash-* artifact."
               );
             }
             if (brokenJobs.length) {

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -34,11 +34,16 @@ jobs:
   fuzz:
     needs: discover
     runs-on: ubuntu-latest
-    timeout-minutes: 300
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       max-parallel: 20
       matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
+    env:
+      # Per-fuzzer budget in seconds. Every harness reads FUZZ_MAX_TIME and caps
+      # itself to it, so this is the only place the budget needs setting. The
+      # 4h constant in each harness stays as the local default and ceiling.
+      FUZZ_MAX_TIME: "1800"
     steps:
       - name: Check out
         uses: actions/checkout@v5
@@ -76,8 +81,8 @@ jobs:
           mkdir -p corpus crashes
           # Stream stdout to the action log (visible) and keep only the last
           # ~5000 lines on disk (capturing libFuzzer's crash dump tail without
-          # letting the file grow unbounded over a 5h run).
-          python fuzz/${{ matrix.fuzzer }} -artifact_prefix=crashes/ -max_total_time=18000 -timeout=30 corpus 2>&1 \
+          # letting the file grow unbounded).
+          python fuzz/${{ matrix.fuzzer }} -artifact_prefix=crashes/ -timeout=30 corpus 2>&1 \
             | python3 -u -c "
           import sys
           from collections import deque
@@ -180,7 +185,7 @@ jobs:
           PY
         env:
           FUZZER_NAME: ${{ matrix.fuzzer }}
-          FUZZER_COMMAND: python fuzz/${{ matrix.fuzzer }} -artifact_prefix=crashes/ -max_total_time=18000 -timeout=30 corpus
+          FUZZER_COMMAND: python fuzz/${{ matrix.fuzzer }} -artifact_prefix=crashes/ -timeout=30 corpus
           FUZZER_SNIPPET: fuzz_failure_${{ matrix.fuzzer }}.txt
 
       - name: Upload failure snippet

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ __pycache__/
 # libFuzzer crash reproducers and corpus
 /crashes/
 /corpus/
+
+# Scratch space
+/tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ __pycache__/
 *.xapk
 *.apk
 
-# libFuzzer crash reproducers
+# libFuzzer crash reproducers and corpus
 /crashes/
+/corpus/

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ __pycache__/
 # APK files
 *.xapk
 *.apk
+
+# libFuzzer crash reproducers
+/crashes/

--- a/custom_components/cardata/soc_wiring.py
+++ b/custom_components/cardata/soc_wiring.py
@@ -593,7 +593,7 @@ def process_soc_descriptors(
         elif descriptor == DESC_CHARGING_POWER:
             method = soc_predictor.get_charging_method(vin)
             if method == "DC" or (method is not None and not _has_ac_power_data(vehicle_state)):
-                power_kw = _parse_power_kw(value, descriptor_payload.get("unit", "")) if value is not None else None
+                power_kw = _parse_power_kw(value, descriptor_payload.get("unit") or "") if value is not None else None
                 aux_kw = _get_aux_kw()
                 soc_predictor.update_power_reading(vin, power_kw, aux_power_kw=aux_kw)
                 if soc_predictor.is_charging(vin):

--- a/fuzz/fuzz_api_parsing.py
+++ b/fuzz/fuzz_api_parsing.py
@@ -24,10 +24,16 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import json
+import logging
 import os
 import sys
 
 import atheris
+
+# Rejected input warns on nearly every iteration, which buried the CI job log
+# under gigabytes. Disabled globally because the effective logger name differs
+# with each harness's import style.
+logging.disable(logging.CRITICAL)
 
 # Default fuzz duration in seconds (4 hours) - exits cleanly when reached
 DEFAULT_MAX_TIME = 4 * 60 * 60

--- a/fuzz/fuzz_auth_token_parsing.py
+++ b/fuzz/fuzz_auth_token_parsing.py
@@ -31,11 +31,10 @@ import types
 
 import atheris
 
-# Silence cardata's loggers so the fuzzer does not emit millions of warning
-# lines. The token-polling retry paths log on every 5xx response, and the
-# fuzzer generates a constant stream of them, which otherwise balloons the
-# run output to hundreds of MB and stalls execution past the CI time limit.
-logging.getLogger("cardata").setLevel(logging.CRITICAL)
+# Rejected input warns on nearly every iteration, which buried the CI job log
+# under gigabytes. Disabled globally because the effective logger name differs
+# with each harness's import style.
+logging.disable(logging.CRITICAL)
 
 # Default fuzz duration in seconds (4 hours) - exits cleanly when reached
 DEFAULT_MAX_TIME = 4 * 60 * 60

--- a/fuzz/fuzz_auth_token_parsing.py
+++ b/fuzz/fuzz_auth_token_parsing.py
@@ -63,8 +63,20 @@ def _install_aiohttp_stub() -> None:
     class ClientError(Exception):
         pass
 
+    class ClientResponseError(ClientError):
+        pass
+
+    class ContentTypeError(ClientResponseError):
+        pass
+
+    class ClientPayloadError(ClientError):
+        pass
+
     aiohttp.ClientTimeout = ClientTimeout
     aiohttp.ClientError = ClientError
+    aiohttp.ClientResponseError = ClientResponseError
+    aiohttp.ContentTypeError = ContentTypeError
+    aiohttp.ClientPayloadError = ClientPayloadError
     sys.modules["aiohttp"] = aiohttp
 
 

--- a/fuzz/fuzz_container_matching.py
+++ b/fuzz/fuzz_container_matching.py
@@ -92,11 +92,24 @@ _install_cardata_package()
 
 with atheris.instrument_imports():
     from cardata import api_parsing
+    from cardata import const
     from cardata import container as container_module
 
 
 def _consume_text(fdp: atheris.FuzzedDataProvider, max_len: int) -> str:
     return fdp.ConsumeUnicodeNoSurrogates(max_len)
+
+
+def _consume_name_or_purpose(fdp: atheris.FuzzedDataProvider, expected: str, max_len: int) -> str:
+    """Return the value the matcher accepts, or free-form text.
+
+    The matcher compares for exact equality, so fuzzer text alone can never
+    reach the code behind the guard.
+    """
+
+    if fdp.ConsumeBool():
+        return expected
+    return _consume_text(fdp, max_len)
 
 
 def _consume_descriptor_value(fdp: atheris.FuzzedDataProvider):
@@ -121,16 +134,24 @@ def _consume_descriptor_list(fdp: atheris.FuzzedDataProvider):
     ]
 
 
+def _consume_descriptors(fdp: atheris.FuzzedDataProvider) -> list:
+    """Return the descriptor set the integration wants, or a fuzzer-built one."""
+
+    if fdp.ConsumeBool():
+        return list(const.HV_BATTERY_DESCRIPTORS)
+    return _consume_descriptor_list(fdp)
+
+
 def _consume_container_dict(fdp: atheris.FuzzedDataProvider) -> dict:
     payload = {}
     if fdp.ConsumeBool():
-        payload["purpose"] = _consume_text(fdp, 40)
+        payload["purpose"] = _consume_name_or_purpose(fdp, const.HV_BATTERY_CONTAINER_PURPOSE, 40)
     if fdp.ConsumeBool():
-        payload["name"] = _consume_text(fdp, 40)
+        payload["name"] = _consume_name_or_purpose(fdp, const.HV_BATTERY_CONTAINER_NAME, 40)
     if fdp.ConsumeBool():
         payload["containerId"] = _consume_text(fdp, 24)
     if fdp.ConsumeBool():
-        payload["technicalDescriptors"] = _consume_descriptor_list(fdp)
+        payload["technicalDescriptors"] = _consume_descriptors(fdp)
     if fdp.ConsumeBool():
         payload[_consume_text(fdp, 10)] = _consume_descriptor_value(fdp)
     return payload
@@ -182,11 +203,10 @@ def TestOneInput(data: bytes) -> None:
     containers = api_parsing.extract_container_items(payload)
 
     manager = object.__new__(container_module.CardataContainerManager)
-    manager._descriptor_signature = (
-        container_module.CardataContainerManager.compute_signature(str_only)
-        if str_only
-        else ""
-    )
+    # An empty signature is a state production cannot reach, since __init__
+    # always stores a sha1 hexdigest, so compute one either way.
+    desired = list(const.HV_BATTERY_DESCRIPTORS) if fdp.ConsumeBool() else str_only
+    manager._descriptor_signature = container_module.CardataContainerManager.compute_signature(desired)
 
     for container in containers:
         manager._matches_hv_container(container)

--- a/fuzz/fuzz_container_matching.py
+++ b/fuzz/fuzz_container_matching.py
@@ -23,11 +23,17 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import logging
 import os
 import sys
 import types
 
 import atheris
+
+# Rejected input warns on nearly every iteration, which buried the CI job log
+# under gigabytes. Disabled globally because the effective logger name differs
+# with each harness's import style.
+logging.disable(logging.CRITICAL)
 
 # Default fuzz duration in seconds (4 hours) - exits cleanly when reached
 DEFAULT_MAX_TIME = 4 * 60 * 60

--- a/fuzz/fuzz_container_matching.py
+++ b/fuzz/fuzz_container_matching.py
@@ -56,12 +56,20 @@ def _install_aiohttp_stub() -> None:
     class ClientError(Exception):
         pass
 
-    class ContentTypeError(Exception):
+    class ClientResponseError(ClientError):
+        pass
+
+    class ContentTypeError(ClientResponseError):
+        pass
+
+    class ClientPayloadError(ClientError):
         pass
 
     aiohttp.ClientTimeout = ClientTimeout
     aiohttp.ClientError = ClientError
+    aiohttp.ClientResponseError = ClientResponseError
     aiohttp.ContentTypeError = ContentTypeError
+    aiohttp.ClientPayloadError = ClientPayloadError
     sys.modules["aiohttp"] = aiohttp
 
 

--- a/fuzz/fuzz_container_matching.py
+++ b/fuzz/fuzz_container_matching.py
@@ -41,7 +41,6 @@ DEFAULT_MAX_TIME = 4 * 60 * 60
 CARDATA_PATH = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "custom_components", "cardata")
 )
-sys.path.insert(0, CARDATA_PATH)
 
 
 def _install_aiohttp_stub() -> None:

--- a/fuzz/fuzz_gps_pairing.py
+++ b/fuzz/fuzz_gps_pairing.py
@@ -303,10 +303,10 @@ with atheris.instrument_imports():
 
 
 class _State:
-    def __init__(self, value, unit=None) -> None:
+    def __init__(self, value, unit=None, timestamp=None) -> None:
         self.value = value
         self.unit = unit
-        self.timestamp = None
+        self.timestamp = timestamp
 
 
 class _Coordinator:
@@ -379,6 +379,28 @@ def _consume_floatish(fdp: atheris.FuzzedDataProvider):
     if choice == 3:
         return _consume_text(fdp, 16)
     return None
+
+
+def _consume_timestamp(fdp: atheris.FuzzedDataProvider) -> str | None:
+    """Build a BMW payload timestamp for one coordinate state.
+
+    The tracker parses these with fromisoformat and pairs a fix when both stamps
+    sit within 5 s of each other, so the seconds field spans a whole minute and
+    straddles that window in both directions. The suffix is drawn per coordinate
+    because a naive stamp next to an aware one is what drives the TypeError
+    fallback in the pairing code. The date and hour are fixed so that a crashing
+    input replays identically.
+    """
+
+    choice = fdp.ConsumeIntInRange(0, 5)
+    if choice == 0:
+        return None
+    if choice == 1:
+        return _consume_text(fdp, 24)
+    second = fdp.ConsumeIntInRange(0, 59)
+    micro = fdp.ConsumeIntInRange(0, 999999)
+    suffix = ("", "Z", "+00:00", "+02:00")[choice - 2]
+    return f"2025-01-01T12:00:{second:02d}.{micro:06d}{suffix}"
 
 
 def _consume_descriptor(fdp: atheris.FuzzedDataProvider) -> str:
@@ -478,10 +500,10 @@ def TestOneInput(data: bytes) -> None:
 
         if descriptor == const.LOCATION_LATITUDE_DESCRIPTOR:
             value = _consume_coordinate_value(fdp, is_lat=True)
-            vin_bucket[descriptor] = _State(value)
+            vin_bucket[descriptor] = _State(value, timestamp=_consume_timestamp(fdp))
         elif descriptor == const.LOCATION_LONGITUDE_DESCRIPTOR:
             value = _consume_coordinate_value(fdp, is_lat=False)
-            vin_bucket[descriptor] = _State(value)
+            vin_bucket[descriptor] = _State(value, timestamp=_consume_timestamp(fdp))
         elif descriptor == const.LOCATION_HEADING_DESCRIPTOR:
             vin_bucket[descriptor] = _State(_consume_floatish(fdp))
         elif descriptor == const.LOCATION_ALTITUDE_DESCRIPTOR:

--- a/fuzz/fuzz_gps_pairing.py
+++ b/fuzz/fuzz_gps_pairing.py
@@ -85,12 +85,20 @@ def _install_aiohttp_stub() -> None:
     class ClientError(Exception):
         pass
 
-    class ContentTypeError(Exception):
+    class ClientResponseError(ClientError):
+        pass
+
+    class ContentTypeError(ClientResponseError):
+        pass
+
+    class ClientPayloadError(ClientError):
         pass
 
     aiohttp.ClientTimeout = ClientTimeout
     aiohttp.ClientError = ClientError
+    aiohttp.ClientResponseError = ClientResponseError
     aiohttp.ContentTypeError = ContentTypeError
+    aiohttp.ClientPayloadError = ClientPayloadError
     sys.modules["aiohttp"] = aiohttp
 
 

--- a/fuzz/fuzz_gps_pairing.py
+++ b/fuzz/fuzz_gps_pairing.py
@@ -23,6 +23,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import logging
 import os
 import sys
 import time
@@ -30,6 +31,11 @@ import types
 from enum import StrEnum
 
 import atheris
+
+# Rejected input warns on nearly every iteration, which buried the CI job log
+# under gigabytes. Disabled globally because the effective logger name differs
+# with each harness's import style.
+logging.disable(logging.CRITICAL)
 
 # Default fuzz duration in seconds (4 hours) - exits cleanly when reached
 DEFAULT_MAX_TIME = 4 * 60 * 60

--- a/fuzz/fuzz_gps_pairing.py
+++ b/fuzz/fuzz_gps_pairing.py
@@ -27,6 +27,7 @@ import os
 import sys
 import time
 import types
+from enum import StrEnum
 
 import atheris
 
@@ -101,6 +102,7 @@ def _install_homeassistant_stubs() -> None:
     components = types.ModuleType("homeassistant.components")
     device_tracker = types.ModuleType("homeassistant.components.device_tracker")
     config_entries = types.ModuleType("homeassistant.config_entries")
+    const = types.ModuleType("homeassistant.const")
     core = types.ModuleType("homeassistant.core")
     helpers = types.ModuleType("homeassistant.helpers")
     dispatcher = types.ModuleType("homeassistant.helpers.dispatcher")
@@ -112,6 +114,28 @@ def _install_homeassistant_stubs() -> None:
     storage = types.ModuleType("homeassistant.helpers.storage")
     util = types.ModuleType("homeassistant.util")
     dt = types.ModuleType("homeassistant.util.dt")
+    unit_conversion = types.ModuleType("homeassistant.util.unit_conversion")
+
+    class UnitOfLength(StrEnum):
+        # Must stay a StrEnum with these exact values: the coordinator compares
+        # raw BMW unit strings such as "km" against these members.
+        KILOMETERS = "km"
+        MILES = "mi"
+
+    class DistanceConverter:
+        # Only km and mi are reachable from the coordinator, so anything else
+        # is stub drift and should be loud rather than silently wrong.
+        _KM_PER_MILE = 1.609344
+
+        @staticmethod
+        def convert(value: float, from_unit: str | None, to_unit: str | None) -> float:
+            if from_unit == to_unit:
+                return value
+            if from_unit == UnitOfLength.MILES and to_unit == UnitOfLength.KILOMETERS:
+                return value * DistanceConverter._KM_PER_MILE
+            if from_unit == UnitOfLength.KILOMETERS and to_unit == UnitOfLength.MILES:
+                return value / DistanceConverter._KM_PER_MILE
+            raise ValueError(f"unsupported conversion: {from_unit} to {to_unit}")
 
     class HomeAssistant:
         def __init__(self) -> None:
@@ -208,10 +232,14 @@ def _install_homeassistant_stubs() -> None:
     device_registry.DeviceInfo = dict
     storage.Store = Store
     dt.parse_datetime = parse_datetime
+    const.UnitOfLength = UnitOfLength
+    unit_conversion.DistanceConverter = DistanceConverter
     util.dt = dt
+    util.unit_conversion = unit_conversion
 
     homeassistant.components = components
     homeassistant.config_entries = config_entries
+    homeassistant.const = const
     homeassistant.core = core
     homeassistant.helpers = helpers
     homeassistant.util = util
@@ -227,6 +255,7 @@ def _install_homeassistant_stubs() -> None:
     sys.modules["homeassistant.components"] = components
     sys.modules["homeassistant.components.device_tracker"] = device_tracker
     sys.modules["homeassistant.config_entries"] = config_entries
+    sys.modules["homeassistant.const"] = const
     sys.modules["homeassistant.core"] = core
     sys.modules["homeassistant.helpers"] = helpers
     sys.modules["homeassistant.helpers.dispatcher"] = dispatcher
@@ -238,6 +267,7 @@ def _install_homeassistant_stubs() -> None:
     sys.modules["homeassistant.helpers.storage"] = storage
     sys.modules["homeassistant.util"] = util
     sys.modules["homeassistant.util.dt"] = dt
+    sys.modules["homeassistant.util.unit_conversion"] = unit_conversion
 
 
 def _install_cardata_package() -> None:

--- a/fuzz/fuzz_http_retry.py
+++ b/fuzz/fuzz_http_retry.py
@@ -24,11 +24,17 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import asyncio
+import logging
 import os
 import sys
 import types
 
 import atheris
+
+# Rejected input warns on nearly every iteration, which buried the CI job log
+# under gigabytes. Disabled globally because the effective logger name differs
+# with each harness's import style.
+logging.disable(logging.CRITICAL)
 
 # Default fuzz duration in seconds (4 hours) - exits cleanly when reached
 DEFAULT_MAX_TIME = 4 * 60 * 60

--- a/fuzz/fuzz_http_retry.py
+++ b/fuzz/fuzz_http_retry.py
@@ -56,8 +56,20 @@ def _install_aiohttp_stub() -> None:
     class ClientError(Exception):
         pass
 
+    class ClientResponseError(ClientError):
+        pass
+
+    class ContentTypeError(ClientResponseError):
+        pass
+
+    class ClientPayloadError(ClientError):
+        pass
+
     aiohttp.ClientTimeout = ClientTimeout
     aiohttp.ClientError = ClientError
+    aiohttp.ClientResponseError = ClientResponseError
+    aiohttp.ContentTypeError = ContentTypeError
+    aiohttp.ClientPayloadError = ClientPayloadError
     sys.modules["aiohttp"] = aiohttp
 
 

--- a/fuzz/fuzz_metadata_normalization.py
+++ b/fuzz/fuzz_metadata_normalization.py
@@ -24,12 +24,18 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import asyncio
+import logging
 import os
 import sys
 import types
 from enum import StrEnum
 
 import atheris
+
+# Rejected input warns on nearly every iteration, which buried the CI job log
+# under gigabytes. Disabled globally because the effective logger name differs
+# with each harness's import style.
+logging.disable(logging.CRITICAL)
 
 # Default fuzz duration in seconds (4 hours) - exits cleanly when reached
 DEFAULT_MAX_TIME = 4 * 60 * 60

--- a/fuzz/fuzz_metadata_normalization.py
+++ b/fuzz/fuzz_metadata_normalization.py
@@ -27,6 +27,7 @@ import asyncio
 import os
 import sys
 import types
+from enum import StrEnum
 
 import atheris
 
@@ -41,6 +42,7 @@ def _install_homeassistant_stubs() -> None:
         return
 
     homeassistant = types.ModuleType("homeassistant")
+    const = types.ModuleType("homeassistant.const")
     core = types.ModuleType("homeassistant.core")
     helpers = types.ModuleType("homeassistant.helpers")
     dispatcher = types.ModuleType("homeassistant.helpers.dispatcher")
@@ -48,6 +50,28 @@ def _install_homeassistant_stubs() -> None:
     entity_registry = types.ModuleType("homeassistant.helpers.entity_registry")
     util = types.ModuleType("homeassistant.util")
     util_dt = types.ModuleType("homeassistant.util.dt")
+    unit_conversion = types.ModuleType("homeassistant.util.unit_conversion")
+
+    class UnitOfLength(StrEnum):
+        # Must stay a StrEnum with these exact values: the coordinator compares
+        # raw BMW unit strings such as "km" against these members.
+        KILOMETERS = "km"
+        MILES = "mi"
+
+    class DistanceConverter:
+        # Only km and mi are reachable from the coordinator, so anything else
+        # is stub drift and should be loud rather than silently wrong.
+        _KM_PER_MILE = 1.609344
+
+        @staticmethod
+        def convert(value: float, from_unit: str | None, to_unit: str | None) -> float:
+            if from_unit == to_unit:
+                return value
+            if from_unit == UnitOfLength.MILES and to_unit == UnitOfLength.KILOMETERS:
+                return value * DistanceConverter._KM_PER_MILE
+            if from_unit == UnitOfLength.KILOMETERS and to_unit == UnitOfLength.MILES:
+                return value / DistanceConverter._KM_PER_MILE
+            raise ValueError(f"unsupported conversion: {from_unit} to {to_unit}")
 
     class HomeAssistant:
         def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
@@ -85,16 +109,21 @@ def _install_homeassistant_stubs() -> None:
     event.async_call_later = async_call_later
     util_dt.parse_datetime = parse_datetime
     util.dt = util_dt
+    util.unit_conversion = unit_conversion
+    const.UnitOfLength = UnitOfLength
+    unit_conversion.DistanceConverter = DistanceConverter
     entity_registry.async_get = async_get_entity_registry
     entity_registry.async_entries_for_config_entry = async_entries_for_config_entry
     helpers.dispatcher = dispatcher
     helpers.event = event
     helpers.entity_registry = entity_registry
+    homeassistant.const = const
     homeassistant.core = core
     homeassistant.helpers = helpers
     homeassistant.util = util
 
     sys.modules["homeassistant"] = homeassistant
+    sys.modules["homeassistant.const"] = const
     sys.modules["homeassistant.core"] = core
     sys.modules["homeassistant.helpers"] = helpers
     sys.modules["homeassistant.helpers.dispatcher"] = dispatcher
@@ -102,6 +131,7 @@ def _install_homeassistant_stubs() -> None:
     sys.modules["homeassistant.helpers.entity_registry"] = entity_registry
     sys.modules["homeassistant.util"] = util
     sys.modules["homeassistant.util.dt"] = util_dt
+    sys.modules["homeassistant.util.unit_conversion"] = unit_conversion
 
 
 def _install_cardata_package() -> None:

--- a/fuzz/fuzz_mqtt_boundary.py
+++ b/fuzz/fuzz_mqtt_boundary.py
@@ -25,6 +25,7 @@
 
 import asyncio
 import json
+import logging
 import os
 import sys
 import types
@@ -102,6 +103,27 @@ asyncio.set_event_loop(_LOOP)
 with atheris.instrument_imports():
     from cardata import stream as stream_module
     from homeassistant.core import HomeAssistant
+
+
+# stream._handle_message wraps its whole body in "except Exception" so that a bad
+# payload cannot kill the MQTT callback thread. That also hides every fault from
+# the fuzzer, which is why this harness could only ever fail by hanging or by
+# running out of memory. Turn the record that catch-all logs back into a raised
+# exception: reaching it at all means an unanticipated path, which is worth
+# reporting even though production deliberately tolerates it.
+class _RaiseSwallowedError(logging.Handler):
+    def emit(self, record: logging.LogRecord) -> None:
+        if record.exc_info and record.exc_info[1] is not None:
+            raise record.exc_info[1]
+
+
+# Pin the level on this logger rather than on its "cardata" parent, because
+# getEffectiveLevel() starts at the logger itself. A later log volume change on
+# the parent then cannot filter the record away and silently disarm the handler.
+# For the same reason this harness deliberately does not call logging.disable().
+_STREAM_LOGGER = logging.getLogger("cardata.stream")
+_STREAM_LOGGER.setLevel(logging.ERROR)
+_STREAM_LOGGER.addHandler(_RaiseSwallowedError())
 
 
 class FakeMessage:
@@ -212,6 +234,10 @@ def TestOneInput(data: bytes) -> None:
 
     if fdp.ConsumeBool():
         manager.set_message_callback(_message_callback)
+        # Keep this override paired with the callback. The real _run_coro_safe
+        # logs through the same cardata.stream logger from a done-callback, and
+        # against this non-running loop it would trip the handler above with a
+        # harness fault rather than an integration one.
         manager._run_coro_safe = lambda coro: _LOOP.run_until_complete(coro)
 
     iterations = fdp.ConsumeIntInRange(1, 6)

--- a/fuzz/fuzz_rate_limit.py
+++ b/fuzz/fuzz_rate_limit.py
@@ -29,6 +29,11 @@ import sys
 
 import atheris
 
+# Rejected input warns on nearly every iteration, which buried the CI job log
+# under gigabytes. Disabled globally because the effective logger name differs
+# with each harness's import style.
+logging.disable(logging.CRITICAL)
+
 # Default fuzz duration in seconds (4 hours) - exits cleanly when reached
 DEFAULT_MAX_TIME = 4 * 60 * 60
 
@@ -39,9 +44,6 @@ sys.path.insert(0, CARDATA_PATH)
 
 with atheris.instrument_imports():
     import ratelimit
-
-
-logging.getLogger("ratelimit").setLevel(logging.CRITICAL)
 
 
 class _FuzzClock:

--- a/fuzz/fuzz_redaction.py
+++ b/fuzz/fuzz_redaction.py
@@ -23,10 +23,16 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import logging
 import os
 import sys
 
 import atheris
+
+# Rejected input warns on nearly every iteration, which buried the CI job log
+# under gigabytes. Disabled globally because the effective logger name differs
+# with each harness's import style.
+logging.disable(logging.CRITICAL)
 
 # Default fuzz duration in seconds (4 hours) - exits cleanly when reached
 DEFAULT_MAX_TIME = 4 * 60 * 60

--- a/fuzz/fuzz_service_parsing.py
+++ b/fuzz/fuzz_service_parsing.py
@@ -24,10 +24,16 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import json
+import logging
 import os
 import sys
 
 import atheris
+
+# Rejected input warns on nearly every iteration, which buried the CI job log
+# under gigabytes. Disabled globally because the effective logger name differs
+# with each harness's import style.
+logging.disable(logging.CRITICAL)
 
 # Default fuzz duration in seconds (4 hours) - exits cleanly when reached
 DEFAULT_MAX_TIME = 4 * 60 * 60

--- a/fuzz/fuzz_stream_payload.py
+++ b/fuzz/fuzz_stream_payload.py
@@ -24,6 +24,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import asyncio
+import logging
 import os
 import sys
 import types
@@ -31,6 +32,11 @@ from datetime import datetime
 from enum import StrEnum
 
 import atheris
+
+# Rejected input warns on nearly every iteration, which buried the CI job log
+# under gigabytes. Disabled globally because the effective logger name differs
+# with each harness's import style.
+logging.disable(logging.CRITICAL)
 
 # Default fuzz duration in seconds (4 hours) - exits cleanly when reached
 DEFAULT_MAX_TIME = 4 * 60 * 60

--- a/fuzz/fuzz_stream_payload.py
+++ b/fuzz/fuzz_stream_payload.py
@@ -28,6 +28,7 @@ import os
 import sys
 import types
 from datetime import datetime
+from enum import StrEnum
 
 import atheris
 
@@ -44,6 +45,7 @@ def _install_homeassistant_stubs() -> None:
         return
 
     homeassistant = types.ModuleType("homeassistant")
+    const = types.ModuleType("homeassistant.const")
     core = types.ModuleType("homeassistant.core")
     helpers = types.ModuleType("homeassistant.helpers")
     dispatcher = types.ModuleType("homeassistant.helpers.dispatcher")
@@ -51,6 +53,28 @@ def _install_homeassistant_stubs() -> None:
     entity_registry = types.ModuleType("homeassistant.helpers.entity_registry")
     util = types.ModuleType("homeassistant.util")
     util_dt = types.ModuleType("homeassistant.util.dt")
+    unit_conversion = types.ModuleType("homeassistant.util.unit_conversion")
+
+    class UnitOfLength(StrEnum):
+        # Must stay a StrEnum with these exact values: the coordinator compares
+        # raw BMW unit strings such as "km" against these members.
+        KILOMETERS = "km"
+        MILES = "mi"
+
+    class DistanceConverter:
+        # Only km and mi are reachable from the coordinator, so anything else
+        # is stub drift and should be loud rather than silently wrong.
+        _KM_PER_MILE = 1.609344
+
+        @staticmethod
+        def convert(value: float, from_unit: str | None, to_unit: str | None) -> float:
+            if from_unit == to_unit:
+                return value
+            if from_unit == UnitOfLength.MILES and to_unit == UnitOfLength.KILOMETERS:
+                return value * DistanceConverter._KM_PER_MILE
+            if from_unit == UnitOfLength.KILOMETERS and to_unit == UnitOfLength.MILES:
+                return value / DistanceConverter._KM_PER_MILE
+            raise ValueError(f"unsupported conversion: {from_unit} to {to_unit}")
 
     class HomeAssistant:
         def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
@@ -93,16 +117,21 @@ def _install_homeassistant_stubs() -> None:
     event.async_call_later = async_call_later
     util_dt.parse_datetime = parse_datetime
     util.dt = util_dt
+    util.unit_conversion = unit_conversion
+    const.UnitOfLength = UnitOfLength
+    unit_conversion.DistanceConverter = DistanceConverter
     entity_registry.async_get = async_get_entity_registry
     entity_registry.async_entries_for_config_entry = async_entries_for_config_entry
     helpers.dispatcher = dispatcher
     helpers.event = event
     helpers.entity_registry = entity_registry
+    homeassistant.const = const
     homeassistant.core = core
     homeassistant.helpers = helpers
     homeassistant.util = util
 
     sys.modules["homeassistant"] = homeassistant
+    sys.modules["homeassistant.const"] = const
     sys.modules["homeassistant.core"] = core
     sys.modules["homeassistant.helpers"] = helpers
     sys.modules["homeassistant.helpers.dispatcher"] = dispatcher
@@ -110,6 +139,7 @@ def _install_homeassistant_stubs() -> None:
     sys.modules["homeassistant.helpers.entity_registry"] = entity_registry
     sys.modules["homeassistant.util"] = util
     sys.modules["homeassistant.util.dt"] = util_dt
+    sys.modules["homeassistant.util.unit_conversion"] = unit_conversion
 
 
 def _install_cardata_package() -> None:

--- a/fuzz/fuzz_stream_payload.py
+++ b/fuzz/fuzz_stream_payload.py
@@ -176,6 +176,15 @@ KNOWN_DESCRIPTORS = list(const.HV_BATTERY_DESCRIPTORS) + [
     "vehicle.isMoving",
 ]
 
+# Syntactically valid VINs (17 chars, no I/O/Q), reused from the tests. The
+# coordinator drops every message whose VIN fails that format check, so the
+# fuzzer needs well formed VINs to reach message ingestion at all.
+VALID_VINS = [
+    "WBA12345678901234",
+    "WBY00000000006306",
+    "WBA00000000008448",
+]
+
 
 def _consume_text(fdp: atheris.FuzzedDataProvider, max_len: int) -> str:
     return fdp.ConsumeUnicodeNoSurrogates(max_len)
@@ -230,6 +239,12 @@ def _consume_unit(fdp: atheris.FuzzedDataProvider):
     if fdp.ConsumeBool():
         return choices[fdp.ConsumeIntInRange(0, len(choices) - 1)]
     return _consume_text(fdp, 8)
+
+
+def _consume_vin(fdp: atheris.FuzzedDataProvider) -> str:
+    if fdp.ConsumeBool():
+        return VALID_VINS[fdp.ConsumeIntInRange(0, len(VALID_VINS) - 1)]
+    return _consume_text(fdp, 20)
 
 
 def _consume_descriptor(fdp: atheris.FuzzedDataProvider) -> str:
@@ -292,6 +307,25 @@ def _existing_max_total_time(args):
     return existing
 
 
+def _check_ingestion_reachable() -> None:
+    """Fail loudly if the coordinator drops the seeded VINs.
+
+    async_handle_message discards a message whose VIN fails the format check,
+    and it does so without the fuzzer noticing. A pool that drifted out of the
+    accepted format would leave a whole run exercising the rejection path only,
+    which is how this harness spent every night doing nothing.
+    """
+    coordinator = coordinator_module.CardataCoordinator(hass=HomeAssistant(_LOOP), entry_id="reach-check")
+    vin = VALID_VINS[0]
+    descriptor = "vehicle.fuzz.reachCheck"
+    _LOOP.run_until_complete(coordinator.async_handle_message({"vin": vin, "data": {descriptor: {"value": 1}}}))
+    if coordinator.get_state(vin, descriptor) is None:
+        raise RuntimeError(f"coordinator ingestion unreachable: VIN {vin} was dropped")
+
+
+_check_ingestion_reachable()
+
+
 def TestOneInput(data: bytes) -> None:
     fdp = atheris.FuzzedDataProvider(data)
     hass = HomeAssistant(_LOOP)
@@ -299,7 +333,7 @@ def TestOneInput(data: bytes) -> None:
 
     message_count = fdp.ConsumeIntInRange(1, 3)
     for _ in range(message_count):
-        vin = _consume_text(fdp, 20) or "FUZZVIN1234567890"
+        vin = _consume_vin(fdp)
         descriptor_count = fdp.ConsumeIntInRange(0, 40)
         data_map = {}
         for _ in range(descriptor_count):

--- a/fuzz/fuzz_units.py
+++ b/fuzz/fuzz_units.py
@@ -23,10 +23,16 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import logging
 import os
 import sys
 
 import atheris
+
+# Rejected input warns on nearly every iteration, which buried the CI job log
+# under gigabytes. Disabled globally because the effective logger name differs
+# with each harness's import style.
+logging.disable(logging.CRITICAL)
 
 # Default fuzz duration in seconds (4 hours) - exits cleanly when reached
 DEFAULT_MAX_TIME = 4 * 60 * 60

--- a/fuzz/fuzz_vin_utils.py
+++ b/fuzz/fuzz_vin_utils.py
@@ -23,10 +23,16 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import logging
 import os
 import sys
 
 import atheris
+
+# Rejected input warns on nearly every iteration, which buried the CI job log
+# under gigabytes. Disabled globally because the effective logger name differs
+# with each harness's import style.
+logging.disable(logging.CRITICAL)
 
 # Default fuzz duration in seconds (4 hours) - exits cleanly when reached
 DEFAULT_MAX_TIME = 4 * 60 * 60


### PR DESCRIPTION
The nightly fuzzing run went red on 12 August, but for the wrong reason: a lost
runner on `fuzz_mqtt_boundary`. Looking into that turned up something worse.

Three harnesses had been dying at import in about fifteen seconds every night
since 8 August, and the jobs reported success every time. `coordinator.py` had
gained `UnitOfLength` and `DistanceConverter` imports, and no harness stubbed
either module.

They stayed green because the `Run fuzzer` step runs under `bash -e` and sets
`pipefail`, so a non-zero exit aborted the script before `exit_code` was written
to `$GITHUB_OUTPUT`. The three steps gated on that output then skipped, because
an unset output compares equal to `'0'`, and `continue-on-error` reported the
step and the job as successful. That gate was unreachable-true by construction:
either the script aborted and wrote no output, or the fuzzer had exited zero. In
eight months the workflow has never reported a fuzzer finding, and all seven
auto-filed issues say "(no snippets were captured)".

So the first commit is the important one. Everything else follows from asking
what else was hidden.

### The workflow

- A crashing fuzzer now fails its job. `continue-on-error` and the `exit_code`
  plumbing are gone and the snippet steps are gated on `failure()`.
- The crashed versus killed classifier was wrong in both directions. A skipped
  step also reports `status: completed`, so a job that died at checkout was filed
  as "fuzzer found a real failure" (run 22985319992), and a cancelled job carries
  an empty steps array, so the lookup returned `undefined` and landed in the same
  branch (run 28421531149, which produced issue #9). It now classifies on the
  step conclusion and reports a setup failure as its own category. A lost runner
  still files nothing, which was deliberate in 4cbe4f9.
- Reproducers are kept. Nothing passed `-artifact_prefix`, so the crashing input
  died with the runner. They now upload under a `fuzz-crash-` name, deliberately
  outside the `fuzz-failure-*` pattern that the reporter inlines into issue bodies.
- The corpus is carried between runs. Every run started from empty, so each night
  rediscovered the same shallow paths: `fuzz_units` reached its final coverage two
  seconds in and then executed 373 million more inputs.
- The budget drops from 4h to 30 minutes through `FUZZ_MAX_TIME`, which every
  harness already reads, taking nightly runner time from about 40 hours to 6.5.

### The harnesses

- The missing `homeassistant` stubs are added. `UnitOfLength` stays a `StrEnum`
  with the real values and `DistanceConverter` keeps the real ratio, otherwise the
  unit swap branch the mileage safeguard exists for is never entered.
- The aiohttp stubs were incomplete. `ClientPayloadError`, `ClientResponseError`
  and `ContentTypeError` appear in `except` clauses in the integration but were
  defined nowhere, and Python evaluates the whole tuple, so reaching one of those
  handlers raises `AttributeError` and the fuzzer would report that instead of the
  real exception. The two `ContentTypeError` stubs that did exist derived from
  `Exception`, so `except aiohttp.ClientError` would not have caught them either.
- Three harnesses could not reach the code they are named for:
  - `fuzz_stream_payload` never got a message past the VIN guard. Measured over
    39881 evaluations, not one passed, and the hard-coded fallback was itself
    invalid because the VIN alphabet excludes I. It now passes 52 per cent of the
    time and coordinator coverage goes from 29 to 47 per cent.
  - `fuzz_container_matching` fed free-form text to a matcher that compares two
    long constants with `==`. Neither matcher had ever executed, which is why that
    job sat at `cov: 17` for four hours.
  - `fuzz_gps_pairing` hard-coded its fake timestamp to `None`, leaving five
    branches dead including the aware versus naive `TypeError` fallback.
  In each case the fuzzer still generates invalid values on the other branches,
  because rejecting bad input is behaviour worth testing.
- `fuzz_mqtt_boundary` could not fail at all. `stream._handle_message` wraps its
  body in a catch-all so a bad payload cannot kill the MQTT callback thread, and
  that is the only thing the harness drives: with a fault injected into
  `json.loads`, none of 60 inputs produced an escaping exception. It now re-raises
  what the catch-all swallows.
- Logging is silenced. Rejected input warned on nearly every iteration and the job
  logs reached 8 to 14 GB each.
- Nothing outside the fuzzing workflow imported `fuzz/`, so this class of breakage
  could only ever surface at 01:00. CI now imports every harness on each push,
  which takes a few seconds and would have caught the original outage. It has
  happened before: f28b231 hit these same three harnesses on 30 June.

### One production change

`soc_wiring.py` called `descriptor_payload.get("unit", "")`, which returns the
stored `None` rather than the default when BMW sends `unit: null`. `_parse_power_kw`
then calls `unit.lower()` inside a `try` that catches only `TypeError` and
`ValueError`, so the `AttributeError` escapes and aborts SOC processing for that
message. `normalize_unit` is typed `str | None` and the same helper is already
called as `unit or ""` twice in that file, so this call site was the outlier.

This is a prerequisite rather than a drive-by: the VIN fix is what makes the
fuzzer reach it.
