### PR TITLE
Add optional leasing section to vehicle card

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,35 @@ Available configuration options:
 | `show_map` | `true` | Inline location map |
 | `map_height` | `120` | Mini map height in pixels |
 | `show_buttons` | `true` | Quick-info tiles (location, mileage, service) |
+| `leasing_entity` | *(empty)* | Sensor entity for the optional leasing section (see below) |
+
+### Leasing Section (optional)
+
+Set `leasing_entity` to any sensor that tracks your lease. The card then shows
+four extra tiles: remaining lease time, current distance balance (actual vs.
+pro-rata target), projected over/under mileage at lease end, and the projected
+cost/refund. The card only displays — all math lives in your sensor.
+
+Expected contract: the sensor **state** is the projected over/under mileage at
+lease end (positive = over), with the sensor's `unit_of_measurement` used for
+display (falls back to km). Attributes:
+
+| Attribute | Meaning |
+|-----------|---------|
+| `days_remaining` / `months_remaining` | Remaining lease time |
+| `deviation` | Actual distance minus pro-rata target today |
+| `projected_cost` | Projected cost (positive) or refund (negative) at lease end, in your HA currency |
+
+Tiles show "—" for missing attributes. Over-mileage and costs render in the
+error color, under-mileage and refunds in the success color. A ready-made
+template blueprint implementing this contract:
+[elmars/ha-leasing-blueprint](https://github.com/elmars/ha-leasing-blueprint)
+
+```yaml
+type: custom:bmw-cardata-vehicle-card
+device_id: abcdef1234567890abcdef1234567890
+leasing_entity: sensor.leasing_mini
+```
 
 ### YAML Configuration
 
@@ -281,6 +310,7 @@ show_image: true
 show_map: true
 map_height: 120
 show_buttons: true
+leasing_entity: sensor.leasing_mini
 ```
 
 To hide the map and quick-info tiles:

--- a/README.md
+++ b/README.md
@@ -257,31 +257,73 @@ Available configuration options:
 
 ### Leasing Section (optional)
 
-Set `leasing_entity` to any sensor that tracks your lease. The card then shows
+Set `leasing_entity` to a sensor that tracks your lease. The card then shows
 four extra tiles: remaining lease time, current distance balance (actual vs.
 pro-rata target), projected over/under mileage at lease end, and the projected
-cost/refund. The card only displays — all math lives in your sensor.
+cost/refund. The card only displays — all math lives in the sensor.
 
-Expected contract: the sensor **state** is the projected over/under mileage at
-lease end (positive = over), with the sensor's `unit_of_measurement` used for
-display (falls back to km). Attributes:
+Over-mileage and costs render in the error color, under-mileage and refunds in
+the success color. Missing attributes show "—". Distances use the sensor's
+`unit_of_measurement` (falls back to km); the cost tile uses your Home
+Assistant currency. Tapping any tile opens the sensor's more-info dialog with
+all details.
+
+#### Setup with the Lease Mileage Tracker blueprint
+
+The section is built against the sensor contract of the
+[Lease Mileage Tracker](https://github.com/elmars/ha-leasing-blueprint)
+template blueprint (requires Home Assistant 2024.10+) — the quickest way to
+get a conforming sensor:
+
+1. Import the blueprint:
+
+   [![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Felmars%2Fha-leasing-blueprint%2Fblob%2Fmain%2Flease_mileage.yaml)
+
+   (Template blueprints do not appear on the Blueprints settings page — that
+   page only lists automation/script blueprints. The import still works.)
+
+2. Create one sensor per vehicle in your YAML configuration, feeding it the
+   mileage sensor this integration provides:
+
+   ```yaml
+   template:
+     - use_blueprint:
+         path: elmars/lease_mileage.yaml
+         input:
+           name: "Lease My BMW"
+           unique_id: lease_my_bmw
+           odometer: sensor.my_bmw_mileage   # mileage sensor from this integration
+           start_date: "2024-12-18"
+           end_date: "2027-12-18"
+           total_distance: 75000
+           excess_rate: 0.40      # per km/mi over, incl. VAT
+           shortfall_rate: 0.25   # per km/mi under, incl. VAT
+           excess_allowance: 1500
+           shortfall_allowance: 1500
+   ```
+
+   Then reload template entities (Developer tools → YAML → Template entities).
+
+3. Point the card at the sensor — via the GUI editor ("Leasing sensor
+   (optional)") or in YAML:
+
+   ```yaml
+   type: custom:bmw-cardata-vehicle-card
+   device_id: abcdef1234567890abcdef1234567890
+   leasing_entity: sensor.lease_my_bmw
+   ```
+
+#### Sensor contract (for custom sensors)
+
+Any sensor works as long as it follows the blueprint's contract: the sensor
+**state** is the projected over/under mileage at lease end (positive = over),
+and it provides these attributes:
 
 | Attribute | Meaning |
 |-----------|---------|
 | `days_remaining` / `months_remaining` | Remaining lease time |
 | `deviation` | Actual distance minus pro-rata target today |
 | `projected_cost` | Projected cost (positive) or refund (negative) at lease end, in your HA currency |
-
-Tiles show "—" for missing attributes. Over-mileage and costs render in the
-error color, under-mileage and refunds in the success color. A ready-made
-template blueprint implementing this contract:
-[elmars/ha-leasing-blueprint](https://github.com/elmars/ha-leasing-blueprint)
-
-```yaml
-type: custom:bmw-cardata-vehicle-card
-device_id: abcdef1234567890abcdef1234567890
-leasing_entity: sensor.leasing_mini
-```
 
 ### YAML Configuration
 

--- a/custom_components/cardata/frontend/bmw-cardata-vehicle-card.js
+++ b/custom_components/cardata/frontend/bmw-cardata-vehicle-card.js
@@ -133,6 +133,36 @@ const humanizeStateValue = (rawState) => {
     .join(" ");
 };
 
+const attrNumber = (stateObj, key) => {
+  const value = Number(stateObj?.attributes?.[key]);
+  return Number.isFinite(value) ? value : NaN;
+};
+
+const formatSignedDistance = (value, unit) => {
+  if (!Number.isFinite(value)) return "—";
+  const rounded = Math.round(value);
+  return `${rounded > 0 ? "+" : ""}${rounded.toLocaleString()} ${unit || "km"}`;
+};
+
+// positive = extra distance / extra cost (alert), negative = under distance / refund (good)
+const leaseDeltaClass = (value) =>
+  !Number.isFinite(value) || Math.round(value) === 0 ? "" : value > 0 ? "alert" : "good";
+
+const formatLeaseRemaining = (days, months) => {
+  if (Number.isFinite(days) && days < 61) return `${Math.max(0, Math.round(days))} d`;
+  if (Number.isFinite(months)) return `${months} mo`;
+  return "—";
+};
+
+const formatLeaseCost = (value, currency) => {
+  if (!Number.isFinite(value)) return "—";
+  try {
+    return new Intl.NumberFormat(undefined, { style: "currency", currency: currency || "EUR" }).format(value);
+  } catch {
+    return `${value.toFixed(2)} ${currency || "EUR"}`;
+  }
+};
+
 class BmwCardataVehicleCard extends HTMLElement {
   setConfig(config) {
     const cfg = config || {};
@@ -151,6 +181,7 @@ class BmwCardataVehicleCard extends HTMLElement {
     if (boolConfig(cfg, "show_image", true)) size += 2;
     if (boolConfig(cfg, "show_map", true)) size += mapHeightConfig(cfg) / CARD_SIZE_UNIT_PX;
     if (boolConfig(cfg, "show_buttons", true)) size += 2;
+    if (cfg.leasing_entity) size += 1;
     return size;
   }
 
@@ -193,6 +224,10 @@ class BmwCardataVehicleCard extends HTMLElement {
           },
         },
         { name: "show_buttons", selector: { boolean: {} } },
+        {
+          name: "leasing_entity",
+          selector: { entity: { domain: "sensor" } },
+        },
       ],
       computeLabel: (schema) => {
         if (schema.name === "device_id") return "Vehicle";
@@ -205,6 +240,7 @@ class BmwCardataVehicleCard extends HTMLElement {
         if (schema.name === "show_map") return "Show mini map";
         if (schema.name === "map_height") return "Mini map height";
         if (schema.name === "show_buttons") return "Show quick info buttons";
+        if (schema.name === "leasing_entity") return "Leasing sensor (optional)";
         return undefined;
       },
     };
@@ -510,6 +546,12 @@ class BmwCardataVehicleCard extends HTMLElement {
           .btn-item.alert .btn-value {
             color: var(--error-color);
           }
+          .btn-item.good .btn-icon {
+            color: var(--success-color);
+          }
+          .btn-item.good .btn-value {
+            color: var(--success-color);
+          }
           .btn-icon {
             width: 34px;
             height: 34px;
@@ -579,6 +621,7 @@ class BmwCardataVehicleCard extends HTMLElement {
               <div id="range_info"></div>
               <div id="mini_map"></div>
               <div id="buttons"></div>
+              <div id="leasing"></div>
             </main>
           </div>
         </ha-card>
@@ -1125,6 +1168,65 @@ class BmwCardataVehicleCard extends HTMLElement {
     } else {
       this._setHtml(buttonsEl, "");
     }
+
+    const leasingEl = this.shadowRoot.getElementById("leasing");
+    const leasingEntityId = typeof cfg.leasing_entity === "string" ? cfg.leasing_entity : "";
+    if (leasingEntityId) {
+      const leaseState = hass?.states?.[leasingEntityId];
+      const leaseAvailable = hasUsableState(leaseState);
+      const daysRemaining = leaseAvailable ? attrNumber(leaseState, "days_remaining") : NaN;
+      const monthsRemaining = leaseAvailable ? attrNumber(leaseState, "months_remaining") : NaN;
+      const deviation = leaseAvailable ? attrNumber(leaseState, "deviation") : NaN;
+      const projectedDelta = leaseAvailable ? Number(leaseState.state) : NaN;
+      const projectedCost = leaseAvailable ? attrNumber(leaseState, "projected_cost") : NaN;
+      const distanceUnit = leaseState?.attributes?.unit_of_measurement || "km";
+      const currency = hass?.config?.currency || "EUR";
+      const leasingItems = [
+        {
+          icon: "mdi:calendar-clock",
+          label: "Lease remaining",
+          value: formatLeaseRemaining(daysRemaining, monthsRemaining),
+          cls: "",
+        },
+        {
+          icon: "mdi:map-marker-distance",
+          label: "km balance",
+          value: formatSignedDistance(deviation, distanceUnit),
+          cls: leaseDeltaClass(deviation),
+        },
+        {
+          icon: "mdi:chart-line",
+          label: "Projected at end",
+          value: formatSignedDistance(projectedDelta, distanceUnit),
+          cls: leaseDeltaClass(projectedDelta),
+        },
+        {
+          icon: "mdi:cash",
+          label: "Cost / refund",
+          value: formatLeaseCost(projectedCost, currency),
+          cls: leaseDeltaClass(projectedCost),
+        },
+      ];
+      this._setHtml(leasingEl, `
+        <div class="buttons-grid">
+          ${leasingItems
+            .map(
+              (item) => `
+            <button class="btn-item${item.cls ? ` ${item.cls}` : ""}" data-entity-id="${escapeHtml(leasingEntityId)}" title="${escapeHtml(leasingEntityId)}">
+              <div class="btn-icon"><ha-icon icon="${item.icon}"></ha-icon></div>
+              <div class="btn-text">
+                <div class="btn-title">${escapeHtml(item.label)}</div>
+                <div class="btn-value">${escapeHtml(item.value)}</div>
+              </div>
+            </button>
+          `
+            )
+            .join("")}
+        </div>
+      `);
+    } else {
+      this._setHtml(leasingEl, "");
+    }
   }
 
   _renderMessage(message) {
@@ -1137,6 +1239,7 @@ class BmwCardataVehicleCard extends HTMLElement {
     const imageEl = this.shadowRoot.getElementById("images");
     const mapEl = this.shadowRoot.getElementById("mini_map");
     const buttonsEl = this.shadowRoot.getElementById("buttons");
+    const leasingEl = this.shadowRoot.getElementById("leasing");
 
     nameEl.textContent = "BMW CarData";
     vinEl.textContent = message;
@@ -1145,6 +1248,7 @@ class BmwCardataVehicleCard extends HTMLElement {
     this._setHtml(imageEl, "");
     this._setHtml(mapEl, "");
     this._setHtml(buttonsEl, "");
+    this._setHtml(leasingEl, "");
   }
 }
 


### PR DESCRIPTION
## What

Adds an optional **leasing section** to the vehicle card: four extra tiles showing remaining lease time, current distance balance (actual vs. pro-rata target), projected over/under mileage at lease end, and projected cost/refund.

## How

- Single new config option `leasing_entity` (entity selector in the GUI editor). Not set → the card behaves exactly as before.
- Display-only: the card reads state + attributes from any user-provided sensor and does no lease math itself. Contract is documented in the README (state = projected over/under mileage, attributes `days_remaining`/`months_remaining`, `deviation`, `projected_cost`).
- Distances use the sensor's `unit_of_measurement` (fallback km), cost uses `hass.config.currency` (fallback EUR).
- Tiles reuse the existing `btn-item`/`buttons-grid` styling; only addition is a `good` (success color) variant next to the existing `alert`. Missing attributes render as "—", never errors.
- No backend changes — only `frontend/bmw-cardata-vehicle-card.js` and README.

## Why

Many leased BMW/Mini vehicles come with mileage allowances; keeping projected over/under mileage and the resulting cost visible right on the vehicle card avoids a second card. Keeping the math in a template sensor keeps the card generic — any lease logic (allowances, rates, units) stays user-side.

The README documents the [Lease Mileage Tracker](https://github.com/elmars/ha-leasing-blueprint) template blueprint as the reference implementation of the contract, with a full setup walkthrough (import blueprint → instantiate one sensor per vehicle from the integration's mileage sensor → point `leasing_entity` at it). The blueprint is a soft dependency only — the card works with any sensor following the documented contract, and without `leasing_entity` nothing changes at all.

Running live here against a Mini Aceman (Mini CarData) with the blueprint sensor — tiles, colors, and more-info all behave as described.

Genereted by Claude ... however Elmar's (mine) head and heart involved ;-)
