### PR TITLE
Configurable leasing tiles + more tile types

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,15 +254,19 @@ Available configuration options:
 | `map_height` | `120` | Mini map height in pixels |
 | `show_buttons` | `true` | Quick-info tiles (location, mileage, service) |
 | `leasing_entity` | *(empty)* | Sensor entity for the optional leasing section (see below) |
+| `leasing_tiles` | `[lease_remaining, monthly_budget, projected, cost]` | Which leasing tiles to show, in order. Available: `lease_remaining`, `monthly_budget`, `monthly_average`, `km_balance`, `driven`, `target`, `projected`, `cost` |
 | `language` | `auto` | Card language: `auto` (follow the Home Assistant UI language), `en`, or `de`. Values formatted by Home Assistant (numbers, units, entity states) follow your HA locale regardless. PRs adding languages are welcome — each language is one dictionary block in `bmw-cardata-vehicle-card.js`. |
 
 ### Leasing Section (optional)
 
 Set `leasing_entity` to a sensor that tracks your lease. The card then shows
-four extra tiles: remaining lease time, the remaining average distance per
-month allowed by the contract, projected over/under mileage at lease end, and
-the projected cost/refund. The card only displays — all math lives in the
-sensor.
+leasing tiles — by default: remaining lease time, the remaining average
+distance per month allowed by the contract, projected over/under mileage at
+lease end, and the projected cost/refund. Which tiles appear (and their
+order) is configurable via `leasing_tiles`; additional tiles are available
+for the monthly average so far, today's balance vs. pro-rata target, total
+distance driven, and today's target. The card only displays — all math lives
+in the sensor.
 
 Over-mileage and costs render in the error color, under-mileage and refunds in
 the success color. Missing attributes show "—". Distances use the sensor's
@@ -318,14 +322,19 @@ get a conforming sensor:
 #### Sensor contract (for custom sensors)
 
 Any sensor works as long as it follows the blueprint's contract: the sensor
-**state** is the projected over/under mileage at lease end (positive = over),
-and it provides these attributes:
+**state** is the projected over/under mileage at lease end (positive = over,
+used by the `projected` tile), and each tile reads one attribute — only the
+attributes of the tiles you enable are required:
 
-| Attribute | Meaning |
-|-----------|---------|
-| `days_remaining` / `months_remaining` | Remaining lease time |
-| `monthly_remaining` | Remaining average distance per month allowed by the contract |
-| `projected_cost` | Projected cost (positive) or refund (negative) at lease end, in your HA currency |
+| Tile | Attribute | Meaning |
+|------|-----------|---------|
+| `lease_remaining` | `days_remaining` / `months_remaining` | Remaining lease time |
+| `monthly_budget` | `monthly_remaining` | Remaining average distance per month allowed by the contract |
+| `monthly_average` | `monthly_average` | Average distance per month so far |
+| `km_balance` | `deviation` | Actual distance minus pro-rata target today |
+| `driven` | `actual` | Distance driven since lease start |
+| `target` | `target` | Pro-rata target distance as of today |
+| `cost` | `projected_cost` | Projected cost (positive) or refund (negative) at lease end, in your HA currency |
 
 ### YAML Configuration
 

--- a/README.md
+++ b/README.md
@@ -259,9 +259,10 @@ Available configuration options:
 ### Leasing Section (optional)
 
 Set `leasing_entity` to a sensor that tracks your lease. The card then shows
-four extra tiles: remaining lease time, current distance balance (actual vs.
-pro-rata target), projected over/under mileage at lease end, and the projected
-cost/refund. The card only displays — all math lives in the sensor.
+four extra tiles: remaining lease time, the remaining average distance per
+month allowed by the contract, projected over/under mileage at lease end, and
+the projected cost/refund. The card only displays — all math lives in the
+sensor.
 
 Over-mileage and costs render in the error color, under-mileage and refunds in
 the success color. Missing attributes show "—". Distances use the sensor's
@@ -323,7 +324,7 @@ and it provides these attributes:
 | Attribute | Meaning |
 |-----------|---------|
 | `days_remaining` / `months_remaining` | Remaining lease time |
-| `deviation` | Actual distance minus pro-rata target today |
+| `monthly_remaining` | Remaining average distance per month allowed by the contract |
 | `projected_cost` | Projected cost (positive) or refund (negative) at lease end, in your HA currency |
 
 ### YAML Configuration

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Available configuration options:
 | `map_height` | `120` | Mini map height in pixels |
 | `show_buttons` | `true` | Quick-info tiles (location, mileage, service) |
 | `leasing_entity` | *(empty)* | Sensor entity for the optional leasing section (see below) |
-| `leasing_tiles` | `[lease_remaining, monthly_budget, projected, cost]` | Which leasing tiles to show, in order. Available: `lease_remaining`, `monthly_budget`, `monthly_average`, `km_balance`, `driven`, `target`, `projected`, `cost` |
+| `leasing_tiles` | `[lease_remaining, monthly_budget, projected, cost]` | Which leasing tiles to show, in order. Available: `lease_remaining`, `monthly_budget`, `monthly_average`, `km_balance`, `driven`, `target`, `total`, `lease_start`, `lease_end`, `projected`, `cost` |
 | `language` | `auto` | Card language: `auto` (follow the Home Assistant UI language), `en`, or `de`. Values formatted by Home Assistant (numbers, units, entity states) follow your HA locale regardless. PRs adding languages are welcome — each language is one dictionary block in `bmw-cardata-vehicle-card.js`. |
 
 ### Leasing Section (optional)
@@ -334,6 +334,8 @@ attributes of the tiles you enable are required:
 | `km_balance` | `deviation` | Actual distance minus pro-rata target today |
 | `driven` | `actual` | Distance driven since lease start |
 | `target` | `target` | Pro-rata target distance as of today |
+| `total` | `total_distance` | Total contract distance allowance |
+| `lease_start` / `lease_end` | `lease_start` / `lease_end` | Contract start / end date (shown in the card language's date format) |
 | `cost` | `projected_cost` | Projected cost (positive) or refund (negative) at lease end, in your HA currency |
 
 ### YAML Configuration

--- a/custom_components/cardata/frontend/bmw-cardata-vehicle-card.js
+++ b/custom_components/cardata/frontend/bmw-cardata-vehicle-card.js
@@ -127,6 +127,9 @@ const TRANSLATIONS = {
     km_balance: "km balance",
     driven: "Driven",
     target_today: "Target today",
+    total_distance: "Total allowance",
+    lease_start: "Lease start",
+    lease_end: "Lease end",
     projected_at_end: "Projected at end",
     cost_refund: "Cost / refund",
     excess_km: "Excess mileage",
@@ -213,6 +216,9 @@ const TRANSLATIONS = {
     km_balance: "km-Saldo",
     driven: "Gefahren",
     target_today: "Soll heute",
+    total_distance: "Gesamtkilometer",
+    lease_start: "Leasingbeginn",
+    lease_end: "Leasingende",
     projected_at_end: "Prognose Vertragsende",
     cost_refund: "Kosten / Erstattung",
     excess_km: "Mehrkilometer",
@@ -288,6 +294,9 @@ const LEASE_TILE_OPTIONS = [
   { value: "km_balance", labelKey: "km_balance" },
   { value: "driven", labelKey: "driven" },
   { value: "target", labelKey: "target_today" },
+  { value: "total", labelKey: "total_distance" },
+  { value: "lease_start", labelKey: "lease_start" },
+  { value: "lease_end", labelKey: "lease_end" },
   { value: "projected", labelKey: "projected_at_end" },
   { value: "cost", labelKey: "cost_refund" },
 ];
@@ -342,6 +351,12 @@ const formatSignedDistance = (value, unit) => {
 const formatAbsDistance = (value, unit) => {
   if (!Number.isFinite(value)) return "—";
   return `${Math.abs(Math.round(value)).toLocaleString()} ${unit || "km"}`;
+};
+
+const formatLeaseDate = (value, lang) => {
+  if (!value) return "—";
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? String(value) : parsed.toLocaleDateString(lang);
 };
 
 // positive = extra distance / extra cost (alert), negative = under distance / refund (good)
@@ -1450,6 +1465,24 @@ class BmwCardataVehicleCard extends HTMLElement {
           icon: "mdi:bullseye-arrow",
           label: t("target_today"),
           value: plainDistance(targetKm),
+          cls: "",
+        },
+        total: {
+          icon: "mdi:road-variant",
+          label: t("total_distance"),
+          value: plainDistance(attr("total_distance")),
+          cls: "",
+        },
+        lease_start: {
+          icon: "mdi:calendar-start",
+          label: t("lease_start"),
+          value: formatLeaseDate(leaseState?.attributes?.lease_start, lang),
+          cls: "",
+        },
+        lease_end: {
+          icon: "mdi:calendar-end",
+          label: t("lease_end"),
+          value: formatLeaseDate(leaseState?.attributes?.lease_end, lang),
           cls: "",
         },
         projected: {

--- a/custom_components/cardata/frontend/bmw-cardata-vehicle-card.js
+++ b/custom_components/cardata/frontend/bmw-cardata-vehicle-card.js
@@ -123,6 +123,10 @@ const TRANSLATIONS = {
     mileage: "Mileage",
     lease_remaining: "Lease remaining",
     monthly_budget: "Remaining/month",
+    monthly_average: "Average/month",
+    km_balance: "km balance",
+    driven: "Driven",
+    target_today: "Target today",
     projected_at_end: "Projected at end",
     cost_refund: "Cost / refund",
     excess_km: "Excess mileage",
@@ -184,6 +188,7 @@ const TRANSLATIONS = {
     "editor.map_height": "Mini map height",
     "editor.show_buttons": "Show quick info buttons",
     "editor.leasing_entity": "Leasing sensor (optional)",
+    "editor.leasing_tiles": "Leasing tiles (order = display order)",
     "editor.language": "Card language",
     "editor.lang_auto": "Auto (Home Assistant language)",
   },
@@ -204,6 +209,10 @@ const TRANSLATIONS = {
     mileage: "Kilometerstand",
     lease_remaining: "Leasing-Restlaufzeit",
     monthly_budget: "Restsaldo/Monat",
+    monthly_average: "Schnitt/Monat",
+    km_balance: "km-Saldo",
+    driven: "Gefahren",
+    target_today: "Soll heute",
     projected_at_end: "Prognose Vertragsende",
     cost_refund: "Kosten / Erstattung",
     excess_km: "Mehrkilometer",
@@ -265,10 +274,24 @@ const TRANSLATIONS = {
     "editor.map_height": "Höhe der Mini-Karte",
     "editor.show_buttons": "Schnellinfo-Kacheln anzeigen",
     "editor.leasing_entity": "Leasing-Sensor (optional)",
+    "editor.leasing_tiles": "Leasing-Kacheln (Reihenfolge = Anzeige)",
     "editor.language": "Kartensprache",
     "editor.lang_auto": "Automatisch (HA-Sprache)",
   },
 };
+
+// value = tile key in the render registry, label = translation key for the editor
+const LEASE_TILE_OPTIONS = [
+  { value: "lease_remaining", labelKey: "lease_remaining" },
+  { value: "monthly_budget", labelKey: "monthly_budget" },
+  { value: "monthly_average", labelKey: "monthly_average" },
+  { value: "km_balance", labelKey: "km_balance" },
+  { value: "driven", labelKey: "driven" },
+  { value: "target", labelKey: "target_today" },
+  { value: "projected", labelKey: "projected_at_end" },
+  { value: "cost", labelKey: "cost_refund" },
+];
+const DEFAULT_LEASE_TILES = ["lease_remaining", "monthly_budget", "projected", "cost"];
 
 const resolveLang = (cfg, hass) => {
   const configured = typeof cfg?.language === "string" && cfg.language !== "auto" ? cfg.language : "";
@@ -358,7 +381,12 @@ class BmwCardataVehicleCard extends HTMLElement {
     if (boolConfig(cfg, "show_image", true)) size += 2;
     if (boolConfig(cfg, "show_map", true)) size += mapHeightConfig(cfg) / CARD_SIZE_UNIT_PX;
     if (boolConfig(cfg, "show_buttons", true)) size += 2;
-    if (cfg.leasing_entity) size += 1;
+    if (cfg.leasing_entity) {
+      const tileCount = Array.isArray(cfg.leasing_tiles) && cfg.leasing_tiles.length
+        ? cfg.leasing_tiles.length
+        : DEFAULT_LEASE_TILES.length;
+      size += Math.ceil(tileCount / 2) / 2;
+    }
     return size;
   }
 
@@ -408,6 +436,16 @@ class BmwCardataVehicleCard extends HTMLElement {
         {
           name: "leasing_entity",
           selector: { entity: { domain: "sensor" } },
+        },
+        {
+          name: "leasing_tiles",
+          selector: {
+            select: {
+              multiple: true,
+              mode: "dropdown",
+              options: LEASE_TILE_OPTIONS.map((opt) => ({ value: opt.value, label: t(opt.labelKey) })),
+            },
+          },
         },
         {
           name: "language",
@@ -1361,31 +1399,60 @@ class BmwCardataVehicleCard extends HTMLElement {
     if (leasingEntityId) {
       const leaseState = hass?.states?.[leasingEntityId];
       const leaseAvailable = hasUsableState(leaseState);
-      const daysRemaining = leaseAvailable ? attrNumber(leaseState, "days_remaining") : NaN;
-      const monthsRemaining = leaseAvailable ? attrNumber(leaseState, "months_remaining") : NaN;
-      const monthlyRemaining = leaseAvailable ? attrNumber(leaseState, "monthly_remaining") : NaN;
+      const attr = (key) => (leaseAvailable ? attrNumber(leaseState, key) : NaN);
+      const daysRemaining = attr("days_remaining");
+      const monthsRemaining = attr("months_remaining");
+      const monthlyRemaining = attr("monthly_remaining");
+      const monthlyAverage = attr("monthly_average");
+      const deviation = attr("deviation");
+      const drivenKm = attr("actual");
+      const targetKm = attr("target");
       const projectedDelta = leaseAvailable ? Number(leaseState.state) : NaN;
-      const projectedCost = leaseAvailable ? attrNumber(leaseState, "projected_cost") : NaN;
+      const projectedCost = attr("projected_cost");
       const distanceUnit = leaseState?.attributes?.unit_of_measurement || "km";
       const currency = hass?.config?.currency || "EUR";
       const projectedDirection = leaseDeltaClass(projectedDelta);
       const costDirection = leaseDeltaClass(projectedCost);
-      const leasingItems = [
-        {
+      const plainDistance = (value) =>
+        Number.isFinite(value) ? `${Math.round(value).toLocaleString()} ${distanceUnit}` : "—";
+      const tileDefs = {
+        lease_remaining: {
           icon: "mdi:calendar-clock",
           label: t("lease_remaining"),
           value: formatLeaseRemaining(daysRemaining, monthsRemaining, t),
           cls: "",
         },
-        {
+        monthly_budget: {
           icon: "mdi:speedometer",
           label: t("monthly_budget"),
-          value: Number.isFinite(monthlyRemaining)
-            ? `${Math.round(monthlyRemaining).toLocaleString()} ${distanceUnit}`
-            : "—",
+          value: plainDistance(monthlyRemaining),
           cls: Number.isFinite(monthlyRemaining) && monthlyRemaining < 0 ? "alert" : "",
         },
-        {
+        monthly_average: {
+          icon: "mdi:chart-timeline-variant",
+          label: t("monthly_average"),
+          value: plainDistance(monthlyAverage),
+          cls: "",
+        },
+        km_balance: {
+          icon: "mdi:map-marker-distance",
+          label: t("km_balance"),
+          value: formatSignedDistance(deviation, distanceUnit),
+          cls: leaseDeltaClass(deviation),
+        },
+        driven: {
+          icon: "mdi:counter",
+          label: t("driven"),
+          value: plainDistance(drivenKm),
+          cls: "",
+        },
+        target: {
+          icon: "mdi:bullseye-arrow",
+          label: t("target_today"),
+          value: plainDistance(targetKm),
+          cls: "",
+        },
+        projected: {
           icon: "mdi:chart-line",
           // Directional label ("excess"/"under") carries the sign, so the value goes unsigned;
           // neutral/unknown keeps the generic label with the signed value.
@@ -1393,13 +1460,17 @@ class BmwCardataVehicleCard extends HTMLElement {
           value: projectedDirection ? formatAbsDistance(projectedDelta, distanceUnit) : formatSignedDistance(projectedDelta, distanceUnit),
           cls: projectedDirection,
         },
-        {
+        cost: {
           icon: "mdi:cash",
           label: costDirection === "alert" ? t("payment_due") : costDirection === "good" ? t("refund") : t("cost_refund"),
           value: costDirection ? formatLeaseCost(Math.abs(projectedCost), currency) : formatLeaseCost(projectedCost, currency),
           cls: costDirection,
         },
-      ];
+      };
+      const selectedTiles = Array.isArray(cfg.leasing_tiles) && cfg.leasing_tiles.length
+        ? cfg.leasing_tiles.filter((key) => tileDefs[key])
+        : DEFAULT_LEASE_TILES;
+      const leasingItems = selectedTiles.map((key) => tileDefs[key]);
       this._setHtml(leasingEl, `
         <div class="buttons-grid">
           ${leasingItems

--- a/custom_components/cardata/frontend/bmw-cardata-vehicle-card.js
+++ b/custom_components/cardata/frontend/bmw-cardata-vehicle-card.js
@@ -122,7 +122,7 @@ const TRANSLATIONS = {
     tire: "Tire",
     mileage: "Mileage",
     lease_remaining: "Lease remaining",
-    km_balance: "km balance",
+    monthly_budget: "Remaining/month",
     projected_at_end: "Projected at end",
     cost_refund: "Cost / refund",
     excess_km: "Excess mileage",
@@ -203,7 +203,7 @@ const TRANSLATIONS = {
     tire: "Reifen",
     mileage: "Kilometerstand",
     lease_remaining: "Leasing-Restlaufzeit",
-    km_balance: "km-Saldo",
+    monthly_budget: "Restsaldo/Monat",
     projected_at_end: "Prognose Vertragsende",
     cost_refund: "Kosten / Erstattung",
     excess_km: "Mehrkilometer",
@@ -1363,7 +1363,7 @@ class BmwCardataVehicleCard extends HTMLElement {
       const leaseAvailable = hasUsableState(leaseState);
       const daysRemaining = leaseAvailable ? attrNumber(leaseState, "days_remaining") : NaN;
       const monthsRemaining = leaseAvailable ? attrNumber(leaseState, "months_remaining") : NaN;
-      const deviation = leaseAvailable ? attrNumber(leaseState, "deviation") : NaN;
+      const monthlyRemaining = leaseAvailable ? attrNumber(leaseState, "monthly_remaining") : NaN;
       const projectedDelta = leaseAvailable ? Number(leaseState.state) : NaN;
       const projectedCost = leaseAvailable ? attrNumber(leaseState, "projected_cost") : NaN;
       const distanceUnit = leaseState?.attributes?.unit_of_measurement || "km";
@@ -1378,10 +1378,12 @@ class BmwCardataVehicleCard extends HTMLElement {
           cls: "",
         },
         {
-          icon: "mdi:map-marker-distance",
-          label: t("km_balance"),
-          value: formatSignedDistance(deviation, distanceUnit),
-          cls: leaseDeltaClass(deviation),
+          icon: "mdi:speedometer",
+          label: t("monthly_budget"),
+          value: Number.isFinite(monthlyRemaining)
+            ? `${Math.round(monthlyRemaining).toLocaleString()} ${distanceUnit}`
+            : "—",
+          cls: Number.isFinite(monthlyRemaining) && monthlyRemaining < 0 ? "alert" : "",
         },
         {
           icon: "mdi:chart-line",


### PR DESCRIPTION
Follow-up to #419/#421 (thanks for the quick merges!). Makes the leasing section's tiles configurable and adds more tile types.

## What

- New `leasing_tiles` config option: choose **which** leasing tiles to show and in **which order** (multi-select in the GUI editor, list in YAML). Default stays the previous four tiles, so existing setups don't change.
- Tile catalog grows from 4 to 11 (all localized en/de, missing attributes render "—"):

| Tile | Sensor source | Shows |
|------|---------------|-------|
| `lease_remaining` | `days_remaining` / `months_remaining` | Remaining lease time |
| `monthly_budget` | `monthly_remaining` | Remaining average distance per month allowed by the contract (red when negative) |
| `monthly_average` | `monthly_average` | Average distance per month so far |
| `km_balance` | `deviation` | Actual vs. pro-rata target today (signed, colored) |
| `driven` | `actual` | Distance driven since lease start |
| `target` | `target` | Pro-rata target distance as of today |
| `total` | `total_distance` | Total contract allowance |
| `lease_start` / `lease_end` | `lease_start` / `lease_end` | Contract dates, formatted per card language |
| `projected` | state | Projected over/under mileage at lease end (directional label) |
| `cost` | `projected_cost` | Projected additional payment / refund (directional label) |

- The projection and cost tiles label themselves by direction — "Excess mileage"/"Under mileage", "Additional payment"/"Refund" (localized) — with unsigned values since the label carries the sign; zero/unknown keeps the neutral generic label.

## Verification

- i18n coverage check: en/de dictionaries in sync (87 keys), every static `t()` key exists, editor labels complete, no empty values; helper smoke tests and `node --check` pass.
- Running live against a Mini Aceman with the [Lease Mileage Tracker](https://github.com/elmars/ha-leasing-blueprint) blueprint sensor, including a custom tile selection via the GUI editor.
- Invalid/unknown tile names in `leasing_tiles` are ignored; empty selection falls back to the default set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
