### PR TITLE
Stop the rate limit backoff running past the quota reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ BMW imposes a **50 calls/day** limit on the CarData API. This integration does n
 - **Fallback polling**: The integration polls periodically as a fallback in case MQTT stream fails or after Home Assistant restarts. VINs with fresh MQTT data are skipped individually, so in multi-car setups only stale VINs consume API calls.
 - **Daily optional features**: When Charging History and/or Tyre Diagnosis are enabled, each makes exactly 1 API call per vehicle per day regardless of whether the call succeeds or fails (no retries). The polling interval automatically increases to compensate — e.g. with both features on 2 cars, polling stretches from 2h to 2.4h per VIN.
 - **Multi-VIN setups**: All vehicles share the same 50 call/day limit. The poll interval scales with VIN count plus any enabled daily features. Each VIN is guaranteed at least 1 poll per day; BMW's 429 backoff handles actual quota enforcement.
-- **Rate limiting**: If BMW returns a rate-limited response (HTTP 429 or HTTP 403 with `CU-429` error code), the integration backs off automatically with exponential delay.
+- **Rate limiting**: If BMW returns a rate-limited response (HTTP 429 or HTTP 403 with `CU-429` error code), the integration backs off automatically with exponential delay (1h, 2h, 4h, 8h, up to 24h). Because the quota resets at midnight UTC, a backoff that would run past the reset is shortened to end at it, so API calls resume as soon as the quota is back instead of sitting out the rest of a long backoff. A `Retry-After` header sent by BMW is honoured as-is.
 
 ## Requirements
 

--- a/custom_components/cardata/bootstrap.py
+++ b/custom_components/cardata/bootstrap.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from datetime import UTC, datetime
 from typing import Any
 
 import aiohttp
@@ -549,6 +550,10 @@ async def async_seed_telematic_data(
         if merged_data:
             await coordinator.async_handle_message({"vin": vin, "data": merged_data})
             coordinator.record_telematic_poll(vin)
+            # The seed is a successful telematic API call, so the diagnostic
+            # sensor should show it instead of staying unknown until the first
+            # scheduled poll succeeds.
+            coordinator.last_telematic_api_at = datetime.now(UTC)
             created = True
             _LOGGER.debug(
                 "Bootstrap seeded %d descriptor(s) for VIN %s from %d container(s)",

--- a/custom_components/cardata/lifecycle.py
+++ b/custom_components/cardata/lifecycle.py
@@ -31,7 +31,6 @@ import asyncio
 import logging
 import time
 from contextlib import suppress
-from datetime import UTC, datetime
 
 import aiohttp
 from homeassistant.config_entries import ConfigEntry
@@ -264,11 +263,11 @@ async def async_setup_cardata(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         coordinator._soc_predictor.set_save_callback(_trigger_save)
         coordinator._magic_soc.set_learning_callback(_trigger_save)
 
-        # Restore stored vehicle metadata
-        last_poll_ts = data.get("last_telematic_poll")
-        if isinstance(last_poll_ts, (int, float)) and last_poll_ts > 0:
-            coordinator.last_telematic_api_at = datetime.fromtimestamp(last_poll_ts, UTC)
-
+        # Restore stored vehicle metadata.
+        # last_telematic_api_at is deliberately not restored here: it feeds the
+        # "Last Telematics API Call" sensor and must only ever hold the time of a
+        # successful fetch, while the stored last_telematic_poll also records
+        # failed and rate limited attempts. The sensor restores its own state.
         await async_restore_vehicle_metadata(hass, entry, coordinator)
 
         # CRITICAL FIX: Pre-populate coordinator.names from restored device_metadata

--- a/custom_components/cardata/ratelimit.py
+++ b/custom_components/cardata/ratelimit.py
@@ -34,6 +34,22 @@ from datetime import datetime
 
 _LOGGER = logging.getLogger(__name__)
 
+# Shortest cooldown we are willing to set, also used as the floor when the
+# cooldown is clamped to the quota reset.
+MIN_COOLDOWN_SECONDS = 60
+
+SECONDS_PER_DAY = 86400
+
+
+def seconds_until_quota_reset(now: float) -> float:
+    """Return seconds from now until BMW's daily quota resets (midnight UTC).
+
+    Unix time counts seconds since midnight UTC with no leap seconds, so the
+    remainder is the UTC time of day. Plain arithmetic keeps this defined for
+    any clock value, including one far in the future.
+    """
+    return SECONDS_PER_DAY - (now % SECONDS_PER_DAY)
+
 
 class RateLimitTracker:
     """Track API rate limits and implement cooldown after 429 errors."""
@@ -59,15 +75,24 @@ class RateLimitTracker:
         # Try to use server's Retry-After header if provided
         server_cooldown = self._parse_retry_after(retry_after)
 
+        cooldown_seconds: float
         if server_cooldown is not None:
             # Use server-specified cooldown, but enforce minimum of 60s and max of 24h
-            cooldown_seconds = max(60, min(server_cooldown, 24 * 3600))
+            cooldown_seconds = max(MIN_COOLDOWN_SECONDS, min(server_cooldown, 24 * 3600))
             cooldown_source = "server Retry-After"
         else:
             # Fall back to exponential cooldown: 1h, 2h, 4h, 8h, max 24h
             cooldown_hours = min(2 ** (self._429_count - 1), 24)
             cooldown_seconds = cooldown_hours * 3600
             cooldown_source = "exponential backoff"
+            # BMW's daily quota resets at midnight UTC, so waiting past that reset
+            # keeps the REST path idle while calls would already succeed again.
+            # Only our own guess is clamped: an explicit Retry-After from BMW is
+            # honoured as sent.
+            until_reset = max(MIN_COOLDOWN_SECONDS, seconds_until_quota_reset(now))
+            if cooldown_seconds > until_reset:
+                cooldown_seconds = until_reset
+                cooldown_source = "exponential backoff, clamped to quota reset"
 
         self._rate_limited_until = now + cooldown_seconds
         reset_time = datetime.fromtimestamp(self._rate_limited_until)

--- a/custom_components/cardata/telematics.py
+++ b/custom_components/cardata/telematics.py
@@ -354,11 +354,13 @@ async def async_telematic_poll_loop(hass: HomeAssistant, entry_id: str) -> None:
     # Targets ~24 total scheduled API calls/day, including daily optional fetches.
     consecutive_failures = 0
     consecutive_auth_failures = 0  # Track auth failures separately
-    # Skip immediate poll on restart if last poll was recent (saves quota)
-    last_poll_at = runtime.coordinator.last_telematic_api_at
-    if last_poll_at is not None:
-        poll_age = (datetime.now(UTC) - last_poll_at).total_seconds()
-        last_check_time = time.time() - poll_age
+    # Skip immediate poll on restart if last poll was recent (saves quota).
+    # This uses the stored attempt time, not the last success: a restart shortly
+    # after a failed or rate limited poll must not retry straight away either.
+    stored_entry = hass.config_entries.async_get_entry(entry_id)
+    stored_poll = stored_entry.data.get("last_telematic_poll") if stored_entry else None
+    if isinstance(stored_poll, (int, float)) and stored_poll > 0:
+        last_check_time = float(stored_poll)
     else:
         last_check_time = 0.0
 


### PR DESCRIPTION
BMW's daily quota resets at midnight UTC, but the exponential backoff after a rate limited response runs 1h, 2h, 4h, 8h and up to 24h without knowing about that reset. A limit hit late in the evening left the REST path idle for hours after the quota was already back, so telematic polling only resumed when the backoff happened to expire.

Clamp the backoff so it never ends later than the next midnight UTC, with a 60 second floor so a limit hit seconds before the reset cannot let a multi-VIN poll burst straight through. An explicit Retry-After from BMW stays untouched, since that is their instruction rather than our own guess.

Refs kvanbiesen/bmw-cardata-ha#424