### PR TITLE
Add binary sensors for window and sunroof opening state

### DIFF
--- a/custom_components/cardata/binary_sensor.py
+++ b/custom_components/cardata/binary_sensor.py
@@ -68,7 +68,61 @@ DOOR_DESCRIPTORS = (
     "vehicle.cabin.door.row2.passenger.isOpen",
 )
 
+WINDOW_BOOL_DESCRIPTORS = ("vehicle.body.trunk.window.isOpen",)
+
 MOTION_DESCRIPTORS = ("vehicle.isMoving",)
+
+# Windows and the sunroof are reported as an enum string instead of a boolean,
+# so they arrive on the sensor platform and cannot drive a device trigger or the
+# standard "is anything open" logic. These descriptors get a binary sensor in
+# addition to the raw string sensor, which stays in place because it carries
+# detail that a boolean cannot express (INTERMEDIATE is neither open nor shut).
+OPENING_STATUS_DESCRIPTORS = {
+    "vehicle.cabin.window.row1.driver.status": BinarySensorDeviceClass.WINDOW,
+    "vehicle.cabin.window.row1.passenger.status": BinarySensorDeviceClass.WINDOW,
+    "vehicle.cabin.window.row2.driver.status": BinarySensorDeviceClass.WINDOW,
+    "vehicle.cabin.window.row2.passenger.status": BinarySensorDeviceClass.WINDOW,
+    "vehicle.cabin.sunroof.status": BinarySensorDeviceClass.OPENING,
+}
+
+# The raw string sensor keeps the descriptor catalogue title. The derived binary
+# sensor needs its own title so that the two entities are told apart in the UI.
+OPENING_STATUS_TITLES = {
+    "vehicle.cabin.window.row1.driver.status": "Window open (front driver)",
+    "vehicle.cabin.window.row1.passenger.status": "Window open (front passenger)",
+    "vehicle.cabin.window.row2.driver.status": "Window open (rear driver)",
+    "vehicle.cabin.window.row2.passenger.status": "Window open (rear passenger)",
+    "vehicle.cabin.sunroof.status": "Sunroof open",
+}
+
+OPENING_CLOSED_VALUES = frozenset({"CLOSED"})
+OPENING_OPEN_VALUES = frozenset({"OPEN", "INTERMEDIATE", "TILTED", "PARTIALLY_OPEN"})
+
+
+def opening_status_to_bool(value: object) -> bool | None:
+    """Map a BMW opening enum string onto a binary sensor state.
+
+    Returns None for anything unrecognised so that an unexpected or newly
+    introduced enum value leaves the sensor untouched. Defaulting to "open"
+    would raise false alarms, and defaulting to "closed" would hide real ones.
+    """
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().upper()
+    if normalized in OPENING_CLOSED_VALUES:
+        return False
+    if normalized in OPENING_OPEN_VALUES:
+        return True
+    return None
+
+
+def coerce_binary_value(descriptor: str, value: object) -> bool | None:
+    """Return the boolean a binary sensor must show, or None if unusable."""
+    if descriptor in OPENING_STATUS_DESCRIPTORS:
+        return opening_status_to_bool(value)
+    if isinstance(value, bool):
+        return value
+    return None
 
 
 class CardataBinarySensor(CardataEntity, RestoreEntity, BinarySensorEntity):
@@ -84,6 +138,17 @@ class CardataBinarySensor(CardataEntity, RestoreEntity, BinarySensorEntity):
             self._attr_device_class = BinarySensorDeviceClass.DOOR
         elif descriptor in MOTION_DESCRIPTORS:
             self._attr_device_class = BinarySensorDeviceClass.MOVING
+        elif descriptor in WINDOW_BOOL_DESCRIPTORS:
+            self._attr_device_class = BinarySensorDeviceClass.WINDOW
+        elif descriptor in OPENING_STATUS_DESCRIPTORS:
+            self._attr_device_class = OPENING_STATUS_DESCRIPTORS[descriptor]
+
+    def _format_name(self) -> str:
+        """Prefer the binary-specific title for derived opening sensors."""
+        title = OPENING_STATUS_TITLES.get(self._descriptor)
+        if title:
+            return title
+        return super()._format_name()
 
     async def async_added_to_hass(self) -> None:
         """Restore state and subscribe to updates."""
@@ -120,10 +185,11 @@ class CardataBinarySensor(CardataEntity, RestoreEntity, BinarySensorEntity):
         # If we restored state, check for fresh data to ensure we're not stuck with old value
         if restored_state:
             state = self._coordinator.get_state(self.vin, self.descriptor)
-            if state and isinstance(state.value, bool):
+            fresh_value = coerce_binary_value(self.descriptor, state.value) if state else None
+            if fresh_value is not None:
                 # Fresh data available - use it (may differ from restored value)
-                if self._attr_is_on != state.value:
-                    self._attr_is_on = state.value
+                if self._attr_is_on != fresh_value:
+                    self._attr_is_on = fresh_value
                     self.schedule_update_ha_state()
 
         # Always do initial update to get current state from coordinator
@@ -156,10 +222,12 @@ class CardataBinarySensor(CardataEntity, RestoreEntity, BinarySensorEntity):
         # updating, since it's never re-invoked just because some other
         # descriptor later pushes the count over the threshold.
         state = self._coordinator.get_state(vin, descriptor)
-        if not state or not isinstance(state.value, bool):
+        if not state:
             return
 
-        new_value = state.value
+        new_value = coerce_binary_value(descriptor, state.value)
+        if new_value is None:
+            return
 
         # SMART FILTERING: Check if sensor's current state differs from new value
         current_value = getattr(self, "_attr_is_on", None)
@@ -191,6 +259,13 @@ class CardataBinarySensor(CardataEntity, RestoreEntity, BinarySensorEntity):
                 return "mdi:circle-outline"
             else:
                 return "mdi:circle"
+
+        # Window and sunroof openings - dynamic icon based on state
+        if self.descriptor and self.descriptor in OPENING_STATUS_DESCRIPTORS:
+            is_open = getattr(self, "_attr_is_on", False)
+            if is_open:
+                return "mdi:car-door"
+            return "mdi:car-door-lock"
 
         # Motion sensors - dynamic icon based on state
         if self.descriptor and self.descriptor in MOTION_DESCRIPTORS:
@@ -231,7 +306,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
         state = coordinator.get_state(vin, descriptor)
         if state:
-            if not isinstance(state.value, bool):
+            # Known opening descriptors always earn an entity. Gating on the
+            # current value would drop the sensor for good if the car happened
+            # to report an unrecognised enum at setup time.
+            if descriptor not in OPENING_STATUS_DESCRIPTORS and not isinstance(state.value, bool):
                 return
         elif not assume_binary and not from_signal:
             return
@@ -252,6 +330,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         ensure_entity(vin, descriptor, from_signal=True)
 
     entry.async_on_unload(async_dispatcher_connect(hass, coordinator.signal_new_binary, async_handle_new_binary_sensor))
+
+    # Opening descriptors carry a string, so they announce themselves on the
+    # sensor signal rather than the binary one.
+    async def async_handle_new_opening_sensor(vin: str, descriptor: str) -> None:
+        if descriptor in OPENING_STATUS_DESCRIPTORS:
+            ensure_entity(vin, descriptor, from_signal=True)
+
+    entry.async_on_unload(
+        async_dispatcher_connect(hass, coordinator.signal_new_sensor, async_handle_new_opening_sensor)
+    )
 
     # Note: We don't subscribe to signal_update for entity creation here.
     # - signal_new_binary handles new boolean descriptors
@@ -276,3 +364,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     # Add binary sensors from coordinator state
     for vin, descriptor in coordinator.iter_descriptors(binary=True):
         ensure_entity(vin, descriptor)
+
+    # Add the derived opening sensors, whose source values are strings
+    for vin, descriptor in coordinator.iter_descriptors(binary=False):
+        if descriptor in OPENING_STATUS_DESCRIPTORS:
+            ensure_entity(vin, descriptor)

--- a/custom_components/cardata/binary_sensor.py
+++ b/custom_components/cardata/binary_sensor.py
@@ -72,21 +72,18 @@ WINDOW_BOOL_DESCRIPTORS = ("vehicle.body.trunk.window.isOpen",)
 
 MOTION_DESCRIPTORS = ("vehicle.isMoving",)
 
-# Windows and the sunroof are reported as an enum string instead of a boolean,
-# so they arrive on the sensor platform and cannot drive a device trigger or the
-# standard "is anything open" logic. These descriptors get a binary sensor in
-# addition to the raw string sensor, which stays in place because it carries
-# detail that a boolean cannot express (INTERMEDIATE is neither open nor shut).
+# Windows and the sunroof report an enum string rather than a boolean, so they
+# arrive on the sensor platform. They get a binary sensor in addition to it.
 OPENING_STATUS_DESCRIPTORS = {
     "vehicle.cabin.window.row1.driver.status": BinarySensorDeviceClass.WINDOW,
     "vehicle.cabin.window.row1.passenger.status": BinarySensorDeviceClass.WINDOW,
     "vehicle.cabin.window.row2.driver.status": BinarySensorDeviceClass.WINDOW,
     "vehicle.cabin.window.row2.passenger.status": BinarySensorDeviceClass.WINDOW,
-    "vehicle.cabin.sunroof.status": BinarySensorDeviceClass.OPENING,
+    # Home Assistant has no trigger integration for the opening device class.
+    "vehicle.cabin.sunroof.status": BinarySensorDeviceClass.WINDOW,
 }
 
-# The raw string sensor keeps the descriptor catalogue title. The derived binary
-# sensor needs its own title so that the two entities are told apart in the UI.
+# The string sensor keeps the catalogue title, so the binary sensor needs its own.
 OPENING_STATUS_TITLES = {
     "vehicle.cabin.window.row1.driver.status": "Window open (front driver)",
     "vehicle.cabin.window.row1.passenger.status": "Window open (front passenger)",
@@ -102,9 +99,7 @@ OPENING_OPEN_VALUES = frozenset({"OPEN", "INTERMEDIATE"})
 def opening_status_to_bool(value: object) -> bool | None:
     """Map a BMW opening enum string onto a binary sensor state.
 
-    Returns None for anything unrecognised so that an unexpected or newly
-    introduced enum value leaves the sensor untouched. Defaulting to "open"
-    would raise false alarms, and defaulting to "closed" would hide real ones.
+    Unrecognised values return None, which leaves the sensor unchanged.
     """
     if not isinstance(value, str):
         return None
@@ -306,9 +301,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
         state = coordinator.get_state(vin, descriptor)
         if state:
-            # Known opening descriptors always earn an entity. Gating on the
-            # current value would drop the sensor for good if the car happened
-            # to report an unrecognised enum at setup time.
+            # Opening descriptors are known upfront and never carry a boolean.
             if descriptor not in OPENING_STATUS_DESCRIPTORS and not isinstance(state.value, bool):
                 return
         elif not assume_binary and not from_signal:

--- a/custom_components/cardata/binary_sensor.py
+++ b/custom_components/cardata/binary_sensor.py
@@ -96,7 +96,7 @@ OPENING_STATUS_TITLES = {
 }
 
 OPENING_CLOSED_VALUES = frozenset({"CLOSED"})
-OPENING_OPEN_VALUES = frozenset({"OPEN", "INTERMEDIATE", "TILTED", "PARTIALLY_OPEN"})
+OPENING_OPEN_VALUES = frozenset({"OPEN", "INTERMEDIATE"})
 
 
 def opening_status_to_bool(value: object) -> bool | None:

--- a/tests/test_opening_binary_sensors.py
+++ b/tests/test_opening_binary_sensors.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2025, Renaud Allard <renaud@allard.it>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for the window and sunroof opening binary sensors."""
+
+import pytest
+
+from custom_components.cardata.binary_sensor import (
+    OPENING_STATUS_DESCRIPTORS,
+    OPENING_STATUS_TITLES,
+    coerce_binary_value,
+    opening_status_to_bool,
+)
+
+WINDOW_DESCRIPTOR = "vehicle.cabin.window.row1.driver.status"
+DOOR_DESCRIPTOR = "vehicle.cabin.door.row1.driver.isOpen"
+
+
+class TestOpeningStatusToBool:
+    """Tests for the opening enum mapping."""
+
+    def test_closed_is_off(self):
+        assert opening_status_to_bool("CLOSED") is False
+
+    @pytest.mark.parametrize("value", ["OPEN", "INTERMEDIATE", "TILTED", "PARTIALLY_OPEN"])
+    def test_open_variants_are_on(self, value):
+        assert opening_status_to_bool(value) is True
+
+    def test_value_is_normalized(self):
+        assert opening_status_to_bool("  closed  ") is False
+        assert opening_status_to_bool("open") is True
+
+    @pytest.mark.parametrize("value", ["UNKNOWN", "NOT_AVAILABLE", "", "INVALID"])
+    def test_unrecognised_values_return_none(self, value):
+        """An unknown enum must not resolve to open, because that raises a false alarm."""
+        assert opening_status_to_bool(value) is None
+
+    @pytest.mark.parametrize("value", [None, 1, 0, 12.5, [], {}])
+    def test_non_string_returns_none(self, value):
+        assert opening_status_to_bool(value) is None
+
+    def test_bool_input_returns_none(self):
+        """A boolean is not an opening enum, so it must not be mapped here."""
+        assert opening_status_to_bool(True) is None
+
+
+class TestCoerceBinaryValue:
+    """Tests for the shared value coercion used by the binary sensor platform."""
+
+    def test_opening_descriptor_maps_string(self):
+        assert coerce_binary_value(WINDOW_DESCRIPTOR, "OPEN") is True
+        assert coerce_binary_value(WINDOW_DESCRIPTOR, "CLOSED") is False
+
+    def test_opening_descriptor_rejects_unknown_string(self):
+        assert coerce_binary_value(WINDOW_DESCRIPTOR, "SOMETHING_NEW") is None
+
+    def test_boolean_descriptor_passes_through(self):
+        assert coerce_binary_value(DOOR_DESCRIPTOR, True) is True
+        assert coerce_binary_value(DOOR_DESCRIPTOR, False) is False
+
+    def test_boolean_descriptor_rejects_string(self):
+        """Existing behaviour is preserved: non-opening descriptors stay boolean-only."""
+        assert coerce_binary_value(DOOR_DESCRIPTOR, "OPEN") is None
+
+    def test_unknown_descriptor_rejects_string(self):
+        assert coerce_binary_value("vehicle.something.else", "OPEN") is None
+
+
+class TestOpeningDescriptorTables:
+    """Tests that keep the descriptor tables consistent."""
+
+    def test_every_descriptor_has_a_title(self):
+        assert set(OPENING_STATUS_DESCRIPTORS) == set(OPENING_STATUS_TITLES)
+
+    def test_titles_are_distinct(self):
+        """Duplicate titles would produce indistinguishable entities."""
+        titles = list(OPENING_STATUS_TITLES.values())
+        assert len(titles) == len(set(titles))

--- a/tests/test_opening_binary_sensors.py
+++ b/tests/test_opening_binary_sensors.py
@@ -26,6 +26,7 @@
 """Tests for the window and sunroof opening binary sensors."""
 
 import pytest
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 
 from custom_components.cardata.binary_sensor import (
     OPENING_STATUS_DESCRIPTORS,
@@ -98,3 +99,8 @@ class TestOpeningDescriptorTables:
         """Duplicate titles would produce indistinguishable entities."""
         titles = list(OPENING_STATUS_TITLES.values())
         assert len(titles) == len(set(titles))
+
+    def test_every_descriptor_is_reachable_from_a_trigger(self):
+        """Home Assistant ships trigger integrations for window and door, but not opening."""
+        reachable = {BinarySensorDeviceClass.WINDOW, BinarySensorDeviceClass.DOOR}
+        assert set(OPENING_STATUS_DESCRIPTORS.values()) <= reachable

--- a/tests/test_opening_binary_sensors.py
+++ b/tests/test_opening_binary_sensors.py
@@ -44,7 +44,7 @@ class TestOpeningStatusToBool:
     def test_closed_is_off(self):
         assert opening_status_to_bool("CLOSED") is False
 
-    @pytest.mark.parametrize("value", ["OPEN", "INTERMEDIATE", "TILTED", "PARTIALLY_OPEN"])
+    @pytest.mark.parametrize("value", ["OPEN", "INTERMEDIATE"])
     def test_open_variants_are_on(self, value):
         assert opening_status_to_bool(value) is True
 
@@ -52,7 +52,7 @@ class TestOpeningStatusToBool:
         assert opening_status_to_bool("  closed  ") is False
         assert opening_status_to_bool("open") is True
 
-    @pytest.mark.parametrize("value", ["UNKNOWN", "NOT_AVAILABLE", "", "INVALID"])
+    @pytest.mark.parametrize("value", ["UNKNOWN", "NOT_AVAILABLE", "", "INVALID", "TILTED", "PARTIALLY_OPEN"])
     def test_unrecognised_values_return_none(self, value):
         """An unknown enum must not resolve to open, because that raises a false alarm."""
         assert opening_status_to_bool(value) is None


### PR DESCRIPTION
## What this changes

BMW reports window and sunroof position as an enum string rather than a boolean, so these descriptors are created on the sensor platform:

- `vehicle.cabin.window.row1.driver.status`
- `vehicle.cabin.window.row1.passenger.status`
- `vehicle.cabin.window.row2.driver.status`
- `vehicle.cabin.window.row2.passenger.status`
- `vehicle.cabin.sunroof.status`

A string sensor cannot be used in a device trigger, and it does not take part in the open/closed handling that Home Assistant gives to a `binary_sensor` with a `window` device class. Anyone who wants an alert for "a window is open" has to write a template binary sensor first.

This adds a binary sensor for each of those descriptors, next to the existing string sensor.

## Why the string sensors stay

A boolean cannot express everything the enum carries. These are the values I have seen on a live CarData stream:

| Descriptor | Values seen |
|---|---|
| the four window descriptors | `CLOSED`, `OPEN` |
| `vehicle.cabin.sunroof.status` | `CLOSED`, `OPEN`, `INTERMEDIATE` |

Replacing the string sensors would also break dashboards and automations for current users, and the bundled vehicle card reads these same descriptors.

## Unknown values

`opening_status_to_bool` returns `None` for any value it does not recognise, and the sensor then keeps its previous state. I picked that over a default because both defaults fail in a way that matters here. Treating an unknown value as open raises false alarms, and treating it as closed hides a window that is genuinely open. If BMW adds another value later, the sensor stops updating rather than reporting something wrong.

Only `CLOSED`, `OPEN` and `INTERMEDIATE` are mapped, because those are the values I have actually seen. Anything else falls through to `None`, so no unverified behavior is baked in.

## Why the sunroof is a window

Home Assistant provides trigger integrations per device class. There is a `window`, `door`, `gate`, `cover` and `garage_door` component, but no `opening` component, so no `*.opened` trigger can ever match a `binary_sensor` classified as `opening`.

I first classified the sunroof as `opening`, which is the more literal reading. That left it unreachable from the `window.opened` trigger that picks up the side windows, so an automation built on device-class triggers silently skipped it. All five opening sensors are now `window`, and a test asserts that every entry in the table uses a device class that a trigger integration actually covers.

## Also included

`vehicle.body.trunk.window.isOpen` was already a binary sensor, but it had no device class. It now reports as a window.

## Testing

- `tests/test_opening_binary_sensors.py` adds 24 tests. They cover the enum mapping, the rejection of unknown and non-string values, the unchanged boolean-only behavior for existing descriptors, and consistency between the descriptor table and the title table.
- Full suite: 241 passed, 15 failed. The 15 failures are in `test_stream.py` and `test_coordinator.py`, and they reproduce on an unmodified checkout of the base commit, so they are not caused by this change.
- `ruff check` and `ruff format --check` are both clean.


