### PR TITLE
Refresh the token BMW rejected instead of reconnecting with it

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ Or:
 ### Reauthorization
 If BMW rejects the token (e.g. because the portal revoked it), please use the Configure > Start Device Authorization Again tool
 
+When BMW refuses the stream using tokens it has just issued, the integration reports that instead of asking you to reauthorize, because the credentials are clearly accepted. That usually means something else holds the one stream connection your account gets, so see the custom MQTT broker section below. If nothing else is connected, the client ID is probably missing the `cardata:streaming:read` scope, which does need a new device authorization.
+
 ### Custom MQTT Broker (optional)
 
 You can switch the live stream from BMW's MQTT endpoint to your own broker (for example via [bmw-mqtt-bridge](https://dj0abr.github.io/bmw-mqtt-bridge/)).

--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ If BMW rejects the token (e.g. because the portal revoked it), please use the Co
 ### Custom MQTT Broker (optional)
 
 You can switch the live stream from BMW's MQTT endpoint to your own broker (for example via [bmw-mqtt-bridge](https://dj0abr.github.io/bmw-mqtt-bridge/)).
+BMW only accepts one active stream connection per account, so anything else already connected with the same credentials (a second Home Assistant instance, evcc, or a bridge) makes BMW refuse this one with `Not authorized` even though the token is valid. Letting a single bridge consume the BMW stream and pointing every consumer at your own broker avoids that.
 BMW authorization is still required; only stream transport changes.
 Expected topic format is `<topic_prefix><VIN>` (default prefix `bmw/`) and payload JSON must include `vin` and `data`.
 Configure it in Home Assistant via **Settings -> Devices & Services -> BMW CarData -> Configure -> MQTT Broker**.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Please try to post only issues relevant to the integration itself on the [Issues
 
 ### Configure button actions
 On the integration main page, there is now a "Configure" button. You can use it to:
-- **Refresh authentication tokens** (will reload integration, might also need HA restart in some problem cases)
+- **Refresh authentication tokens** (always requests a new set of tokens from BMW, even when the current ones have not expired yet; will reload integration, might also need HA restart in some problem cases)
 - **Start device authorization again** (redo the whole auth flow)
 - **MQTT Broker** (switch stream source to a custom broker, including TLS mode and topic prefix)
 - **Reset telemetry container** (delete and recreate the BMW telemetry container)

--- a/custom_components/cardata/auth.py
+++ b/custom_components/cardata/auth.py
@@ -259,6 +259,44 @@ async def _do_token_refresh(
         runtime.reauth_pending = False
 
 
+def _report_connection_conflict(
+    hass: HomeAssistant,
+    runtime: CardataRuntimeData,
+    entry: ConfigEntry,
+    notification_id: str,
+) -> None:
+    """Tell the user their credentials are fine and the stream slot is not.
+
+    BMW just issued these tokens and then refused the stream with them, so
+    another client is holding the one connection the account gets, or this
+    client was never granted the streaming scope. Reauthorising helps with
+    the second case only, so say so instead of demanding it.
+    """
+    runtime.connection_conflict = True
+    runtime.reauth_pending = False
+    _LOGGER.error(
+        "BMW refused the data stream for entry %s with tokens it had just issued, so the "
+        "credentials are not the problem. BMW allows one stream connection per account: "
+        "disconnect whatever else is using it, or feed this integration from your own MQTT "
+        "broker. If nothing else is connected, the client ID may be missing the "
+        "cardata:streaming:read scope, which needs a new device authorization.",
+        entry.entry_id,
+    )
+    persistent_notification.async_create(
+        hass,
+        "BMW refused the data stream using tokens it had just issued, so your credentials "
+        "are not the problem.\n\n"
+        "BMW only allows one stream connection per account. Disconnect whatever else is "
+        "using it (a second Home Assistant, evcc, or an MQTT bridge), or point this "
+        "integration at your own broker via Configure > MQTT Broker.\n\n"
+        "If nothing else is connected, your client ID may be missing the "
+        "cardata:streaming:read scope. In that case use Configure > Start Device "
+        "Authorization Again.",
+        title="Bmw Cardata",
+        notification_id=notification_id,
+    )
+
+
 async def handle_stream_error(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -299,6 +337,21 @@ async def handle_stream_error(
         try:
             now = time.time()
 
+            if runtime.connection_conflict:
+                # Already diagnosed as something other than our credentials, so
+                # a refresh would not change BMW's answer. Keep reconnecting
+                # anyway: getting in is the only way we learn the connection
+                # has been freed, and nothing else would clear the verdict.
+                _LOGGER.debug(
+                    "Stream still refused for entry %s with credentials BMW accepts; retrying without a refresh",
+                    entry.entry_id,
+                )
+                try:
+                    await runtime.stream.async_start()
+                except Exception as start_err:
+                    _LOGGER.debug("BMW still refuses the stream for entry %s: %s", entry.entry_id, start_err)
+                return
+
             if runtime.reauth_pending:
                 _LOGGER.debug(
                     "Reauth pending for entry %s after failed refresh; starting flow",
@@ -334,6 +387,9 @@ async def handle_stream_error(
                     try:
                         await runtime.stream.async_start()
                     except Exception as start_err:
+                        if runtime.stream.credentials_refused:
+                            _report_connection_conflict(hass, runtime, entry, notification_id)
+                            return
                         _LOGGER.warning("MQTT reconnect after credential refresh failed: %s", start_err)
                     return
 
@@ -396,9 +452,10 @@ async def handle_stream_error(
             runtime._handling_unauthorized = False
 
     elif reason == "recovered":
-        if runtime.reauth_in_progress:
+        if runtime.reauth_in_progress or runtime.connection_conflict:
             runtime.reauth_in_progress = False
-            _LOGGER.debug("BMW stream connection restored; dismissing reauth notification")
+            runtime.connection_conflict = False
+            _LOGGER.debug("BMW stream connection restored; dismissing notification")
             persistent_notification.async_dismiss(hass, notification_id)
             if runtime.reauth_flow_id:
                 with suppress(Exception):
@@ -633,6 +690,9 @@ async def async_token_refresh_loop(hass: HomeAssistant, entry_id: str) -> None:
                     # Re-fetch entry in case it changed during token refresh
                     reauth_entry = hass.config_entries.async_get_entry(entry_id)
                     if reauth_entry:
+                        # BMW has stopped issuing tokens, so whatever we concluded
+                        # from it still accepting them no longer holds.
+                        runtime.connection_conflict = False
                         await handle_stream_error(hass, reauth_entry, "unauthorized")
                     # Continue loop but with max backoff until reauth succeeds
                     # The reauth flow will update credentials and reset state

--- a/custom_components/cardata/auth.py
+++ b/custom_components/cardata/auth.py
@@ -182,9 +182,7 @@ async def refresh_tokens_for_entry(
             if not force:
                 expired, seconds_left = is_token_expired(entry, buffer_seconds)
                 if not expired:
-                    _LOGGER.debug(
-                        "Token was refreshed by another caller; skipping (valid for %s seconds)", seconds_left
-                    )
+                    _LOGGER.debug("Token does not need a refresh yet; skipping (valid for %s seconds)", seconds_left)
                     return
             await _do_token_refresh(entry, session, manager, container_manager, hass)
         finally:

--- a/custom_components/cardata/auth.py
+++ b/custom_components/cardata/auth.py
@@ -148,8 +148,13 @@ async def refresh_tokens_for_entry(
     manager: CardataStreamManager,
     container_manager: CardataContainerManager | None = None,
     buffer_seconds: int = TOKEN_EXPIRY_BUFFER_SECONDS,
+    force: bool = False,
 ) -> None:
     """Refresh tokens and update entry data.
+
+    Set force when the tokens have been rejected by BMW. The local expiry
+    data only says when we expect the token to die, it does not say whether
+    BMW still accepts it, so the expiry check has to be skipped in that case.
 
     CRITICAL: This function ONLY handles token refresh.
     Container management is handled separately to avoid API hammering.
@@ -174,10 +179,13 @@ async def refresh_tokens_for_entry(
         # Lock is now acquired - use try/finally immediately to ensure release
         try:
             # double check if token still needs refresh
-            expired, seconds_left = is_token_expired(entry, buffer_seconds)
-            if not expired:
-                _LOGGER.debug("Token was refreshed by another caller; skipping (valid for %s seconds)", seconds_left)
-                return
+            if not force:
+                expired, seconds_left = is_token_expired(entry, buffer_seconds)
+                if not expired:
+                    _LOGGER.debug(
+                        "Token was refreshed by another caller; skipping (valid for %s seconds)", seconds_left
+                    )
+                    return
             await _do_token_refresh(entry, session, manager, container_manager, hass)
         finally:
             lock.release()
@@ -303,11 +311,16 @@ async def handle_stream_error(
                 try:
                     _LOGGER.debug("Attempting token refresh after auth failure")
 
+                    # BMW refused the credentials we hold, so refresh them even
+                    # when they still look valid here. Without force the refresh
+                    # is skipped for the whole 45 minutes between two proactive
+                    # refreshes and we reconnect with the same rejected token.
                     await refresh_tokens_for_entry(
                         entry,
                         runtime.session,
                         runtime.stream,
                         runtime.container_manager,
+                        force=True,
                     )
 
                     # Success! Reset the unauthorized flags
@@ -403,11 +416,14 @@ async def async_manual_refresh_tokens(hass: HomeAssistant, entry: ConfigEntry) -
     if runtime is None:
         raise CardataAuthError("Integration runtime not ready")
 
+    # The user asked for new tokens, so give them new tokens instead of
+    # silently keeping the ones that are already in trouble.
     await refresh_tokens_for_entry(
         entry,
         runtime.session,
         runtime.stream,
         runtime.container_manager,
+        force=True,
     )
 
 

--- a/custom_components/cardata/runtime.py
+++ b/custom_components/cardata/runtime.py
@@ -71,6 +71,9 @@ class CardataRuntimeData:
     last_reauth_attempt: float = 0.0
     last_refresh_attempt: float = 0.0
     reauth_pending: bool = False
+    # Set when BMW refuses the stream with credentials it has just issued,
+    # which means the credentials are not what it objects to.
+    connection_conflict: bool = False
     _handling_unauthorized: bool = False
     soc_store: Store | None = None
 

--- a/custom_components/cardata/stream.py
+++ b/custom_components/cardata/stream.py
@@ -425,12 +425,18 @@ class CardataStreamManager:
             topic = f"{self._gcid}/+"
             client_id = self._gcid
 
+        # reconnect_on_failure=False: after a lost connection paho would run its
+        # own reconnect loop in the network thread, in parallel with ours and
+        # without the backoff, the circuit breaker or the token refresh. Both
+        # would then connect under the same client id, and the broker drops the
+        # older session whenever the newer one arrives.
         client = mqtt.Client(
             client_id=client_id,
             clean_session=True,
             userdata={"topic": topic},
             protocol=mqtt.MQTTv311,
             transport="tcp",
+            reconnect_on_failure=False,
         )
         if debug_enabled():
             _LOGGER.debug(

--- a/custom_components/cardata/stream.py
+++ b/custom_components/cardata/stream.py
@@ -335,22 +335,28 @@ class CardataStreamManager:
         self._intentional_disconnect = True
         self._connection_state = ConnectionState.DISCONNECTING
 
-        disconnect_future: asyncio.Future[None] | None = None
         client = self._client
         self._client = None
         if client is not None:
             loop = asyncio.get_running_loop()
-            disconnect_future = loop.create_future()
+            disconnect_future: asyncio.Future[None] = loop.create_future()
             self._disconnect_future = disconnect_future
             userdata = getattr(client, "_userdata", None)
             if isinstance(userdata, dict):
                 userdata["reconnect"] = False
             try:
-                client.disconnect()
+                rc = client.disconnect()
             except Exception as err:  # pragma: no cover - defensive logging
                 if debug_enabled():
                     _LOGGER.debug("Error disconnecting BMW MQTT client: %s", err)
-            if disconnect_future is not None:
+                rc = mqtt.MQTT_ERR_NO_CONN
+            if rc == mqtt.MQTT_ERR_NO_CONN:
+                # The socket was already gone, usually because we are cleaning
+                # up after a connection loss. No DISCONNECT went out and
+                # on_disconnect has already fired, so nothing will ever
+                # complete the future and waiting just burns the timeout.
+                self._disconnect_future = None
+            else:
                 try:
                     await asyncio.wait_for(disconnect_future, timeout=5)
                 except TimeoutError:

--- a/custom_components/cardata/stream.py
+++ b/custom_components/cardata/stream.py
@@ -609,6 +609,13 @@ class CardataStreamManager:
                         )
                     return
 
+                if self._status_callback:
+                    self._run_coro_safe(
+                        cast(
+                            Coroutine[Any, Any, None],
+                            self._status_callback("connection_failed", mqtt.connack_string(rc).rstrip(".")),
+                        )
+                    )
                 stream_reconnect.schedule_retry(self, 10)
                 return
 
@@ -702,13 +709,9 @@ class CardataStreamManager:
             _LOGGER.exception("Unexpected error in MQTT message handler: %s", err)
 
     def _handle_disconnect(self, client: mqtt.Client, userdata, rc) -> None:
-        reason = {
-            1: "Unacceptable protocol version",
-            2: "Identifier rejected",
-            3: "Server unavailable",
-            4: "Bad username or password",
-            5: "Not authorized",
-        }.get(rc, "Unknown")
+        # The disconnect rc is a paho MQTT_ERR_* code, not a CONNACK code, so
+        # let paho name it rather than reading it as a connection return code.
+        reason = mqtt.error_string(rc).rstrip(".")
 
         # If _connect_event is still pending, the TCP connection failed before
         # the MQTT handshake completed (on_connect was never called).
@@ -719,25 +722,27 @@ class CardataStreamManager:
 
         # Only log if not an intentional disconnect
         if not self._intentional_disconnect:
-            if rc == 0:
+            if rc == mqtt.MQTT_ERR_SUCCESS:
                 # clean disconnect
                 if debug_enabled():
                     _LOGGER.debug("BMW MQTT disconnected cleanly")
-            elif rc == 7:
+            elif rc in (mqtt.MQTT_ERR_CONN_LOST, mqtt.MQTT_ERR_KEEPALIVE):
+                # The broker or the network dropped the socket. We reconnect,
+                # so this is not worth alarming the user about.
                 if debug_enabled():
-                    _LOGGER.debug("BMW MQTT disconnected due to client inactivity")
-            elif rc in (4, 5):
-                _LOGGER.debug("Authorized BMW MQTT disconnect rc=%s (%s)", rc, reason)
+                    _LOGGER.debug("BMW MQTT connection lost (%s)", reason)
+            elif rc == mqtt.MQTT_ERR_CONN_REFUSED:
+                if debug_enabled():
+                    _LOGGER.debug("BMW MQTT refused the connection; handled by the connect callback")
             else:
                 _LOGGER.warning("BMW MQTT disconnected rc=%s (%s)", rc, reason)
         elif debug_enabled():
             _LOGGER.debug("BMW MQTT intentional disconnect rc=%s", rc)
 
-        previous_disconnect = self._last_disconnect
         self._last_disconnect = time.monotonic()
 
-        # Update connection state — skip if already FAILED (set by _handle_connect
-        # for rc=4/5) to prevent double-counting in circuit breaker
+        # Update connection state - skip if already FAILED (set by _handle_connect
+        # for a refused CONNACK) to prevent double-counting in circuit breaker
         if self._connection_state not in (ConnectionState.DISCONNECTING, ConnectionState.FAILED):
             self._connection_state = ConnectionState.DISCONNECTED
             if rc != 0:
@@ -761,37 +766,16 @@ class CardataStreamManager:
             should_reconnect = userdata.get("reconnect", True)
             userdata["reconnect"] = True
 
-        if rc in (4, 5):
-            if self._custom_broker:
-                # Custom broker: just reconnect, don't trigger BMW reauth
-                if self._custom_auth_retry_blocked:
-                    reason = "Custom MQTT auth failed repeatedly; automatic retries stopped"
-                    if self._status_callback:
-                        self._run_coro_safe(
-                            cast(Coroutine[Any, Any, None], self._status_callback("unauthorized_blocked", reason))
-                        )
-                    return
-                if should_reconnect and not self._circuit_breaker.check():
-                    self._run_coro_safe(stream_reconnect.async_reconnect(self))
-                if self._status_callback:
-                    self._run_coro_safe(
-                        cast(Coroutine[Any, Any, None], self._status_callback("connection_failed", reason))
-                    )
-                return
-            now = time.monotonic()
-            if rc == 5 and previous_disconnect is not None and now - previous_disconnect < 10:
-                if debug_enabled():
-                    _LOGGER.debug("Ignoring transient MQTT rc=5; scheduling retry instead")
-                stream_reconnect.schedule_retry(self, 3)
-                return
-            self._run_coro_safe(stream_reconnect.handle_unauthorized(self))
-            if self._status_callback:
-                self._run_coro_safe(cast(Coroutine[Any, Any, None], self._status_callback("unauthorized", reason)))
-        else:
-            if should_reconnect and not self._circuit_breaker.check():
-                self._run_coro_safe(stream_reconnect.async_reconnect(self))
-            if self._status_callback:
-                self._run_coro_safe(cast(Coroutine[Any, Any, None], self._status_callback("disconnected", reason)))
+        # A refused connection always reaches _handle_connect first, carrying
+        # the CONNACK code that says why. That callback owns the recovery, so
+        # starting a second one from here only fights with it.
+        if rc == mqtt.MQTT_ERR_CONN_REFUSED:
+            return
+
+        if should_reconnect and not self._circuit_breaker.check():
+            self._run_coro_safe(stream_reconnect.async_reconnect(self))
+        if self._status_callback:
+            self._run_coro_safe(cast(Coroutine[Any, Any, None], self._status_callback("disconnected", reason)))
 
     def set_credentials(
         self,

--- a/custom_components/cardata/stream.py
+++ b/custom_components/cardata/stream.py
@@ -143,6 +143,9 @@ class CardataStreamManager:
         # Threading event for connection synchronization (avoids global socket timeout)
         self._connect_event: threading.Event | None = None
         self._connect_rc: int | None = None
+        # CONNACK code of the last attempt, set only from the connect callback
+        # so it always holds a broker verdict and never a socket error code.
+        self._last_connack_rc: int | None = None
         # Circuit breaker persistence serialization
         self._persist_lock = asyncio.Lock()
 
@@ -227,6 +230,10 @@ class CardataStreamManager:
                 await async_update_entry_data(self.hass, entry, {"circuit_breaker_state": state})
 
     async def _async_start_locked(self) -> None:
+        # Forget the previous verdict so callers cannot read it as the outcome
+        # of an attempt that never reached the broker.
+        self._last_connack_rc = None
+
         # CRITICAL: Don't start MQTT if bootstrap is still in progress
         # Blocks reconnects, retries, and credential updates until bootstrap finishes
         if getattr(self, "_bootstrap_in_progress", False):
@@ -373,6 +380,15 @@ class CardataStreamManager:
     @property
     def client(self) -> mqtt.Client | None:
         return self._client
+
+    @property
+    def credentials_refused(self) -> bool:
+        """Tell whether the broker rejected the credentials of the last attempt.
+
+        False when the attempt failed short of a CONNACK, so a timeout or a
+        TLS problem is never mistaken for a rejection.
+        """
+        return self._last_connack_rc in (4, 5)
 
     def set_message_callback(self, callback: Callable[[dict], Awaitable[None]]) -> None:
         self._message_callback = callback
@@ -557,6 +573,7 @@ class CardataStreamManager:
     def _handle_connect(self, client: mqtt.Client, userdata, flags, rc) -> None:
         # Signal the connect event for synchronous waiters (used during initial connection)
         self._connect_rc = rc
+        self._last_connack_rc = rc
         if self._connect_event is not None:
             self._connect_event.set()
 

--- a/custom_components/cardata/stream_reconnect.py
+++ b/custom_components/cardata/stream_reconnect.py
@@ -41,6 +41,22 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
+def _reconnect_abandoned(manager: CardataStreamManager) -> bool:
+    """Tell whether a reconnect that slept should give up.
+
+    An async_stop() or an entry unload can happen while we wait, and the
+    config entry may be gone by the time we wake up.
+    """
+    if manager._intentional_disconnect:
+        return True
+    if manager._entry_id:
+        from .const import DOMAIN
+
+        if manager._entry_id not in manager.hass.data.get(DOMAIN, {}):
+            return True
+    return False
+
+
 async def async_reconnect(manager: CardataStreamManager) -> None:
     """Handle MQTT reconnection with token refresh and backoff."""
     from .stream import ConnectionState
@@ -76,9 +92,16 @@ async def async_reconnect(manager: CardataStreamManager) -> None:
     manager._intentional_disconnect = False
 
     if manager._circuit_breaker.check():
+        # The breaker only resets when something checks it again, and the
+        # scheduled retries refuse to run while it is open, so returning here
+        # would leave the stream down until the next token refresh. Wait the
+        # cooldown out instead.
+        cooldown = (manager._circuit_breaker.remaining_seconds or 0) + 1
         if debug_enabled():
-            _LOGGER.debug("Skipping MQTT reconnect due to open circuit breaker")
-        return
+            _LOGGER.debug("Waiting %s seconds for the MQTT circuit breaker to reset", cooldown)
+        await asyncio.sleep(cooldown)
+        if _reconnect_abandoned(manager):
+            return
 
     # Phase 2: Token refresh (no lock needed - client is stopped)
     # Skip token refresh when using a custom MQTT broker (no BMW auth needed)
@@ -116,14 +139,8 @@ async def async_reconnect(manager: CardataStreamManager) -> None:
 
     await asyncio.sleep(wait_time)
 
-    # Re-check after sleep — async_stop or entry unload may have occurred
-    if manager._intentional_disconnect:
+    if _reconnect_abandoned(manager):
         return
-    if manager._entry_id:
-        from .const import DOMAIN
-
-        if manager._entry_id not in manager.hass.data.get(DOMAIN, {}):
-            return
 
     # Phase 4: Start the client (requires lock)
     try:

--- a/custom_components/cardata/stream_reconnect.py
+++ b/custom_components/cardata/stream_reconnect.py
@@ -194,43 +194,47 @@ async def handle_unauthorized(manager: CardataStreamManager) -> None:
         # double-bump.
         manager._reconnect_backoff = min(manager._reconnect_backoff * 2, manager._max_backoff)
 
-        try:
-            unauthorized_protection = None
-            if manager._entry_id:
-                from .const import DOMAIN
+        unauthorized_protection = None
+        if manager._entry_id:
+            from .const import DOMAIN
 
-                runtime = manager.hass.data.get(DOMAIN, {}).get(manager._entry_id)
-                if runtime:
-                    unauthorized_protection = runtime.unauthorized_protection
+            runtime = manager.hass.data.get(DOMAIN, {}).get(manager._entry_id)
+            if runtime:
+                unauthorized_protection = runtime.unauthorized_protection
 
-            if unauthorized_protection:
-                can_retry, block_reason = unauthorized_protection.can_retry()
-                if not can_retry:
-                    blocked = True
+        if unauthorized_protection:
+            can_retry, block_reason = unauthorized_protection.can_retry()
+            if not can_retry:
+                blocked = True
 
-            if not blocked:
-                # Update flags while holding the lock to prevent races
-                manager._awaiting_new_credentials = True
-                should_notify = not manager._reauth_notified
-                if should_notify:
-                    manager._reauth_notified = True
-        finally:
-            manager._unauthorized_retry_in_progress = False
+        if not blocked:
+            # Update flags while holding the lock to prevent races
+            manager._awaiting_new_credentials = True
+            should_notify = not manager._reauth_notified
+            if should_notify:
+                manager._reauth_notified = True
 
-    # Perform all callbacks outside the lock to avoid long lock holds
-    if blocked:
-        _LOGGER.error("BMW MQTT unauthorized retry blocked: %s", block_reason)
-        await manager.async_stop()
+    # Perform all callbacks outside the lock to avoid long lock holds. The
+    # in-progress flag stays set until they are done, otherwise it only spans
+    # the few lines above and a second refusal arriving while we still refresh
+    # the token and restart the stream starts the whole handling again.
+    try:
+        if blocked:
+            _LOGGER.error("BMW MQTT unauthorized retry blocked: %s", block_reason)
+            await manager.async_stop()
+            if manager._status_callback:
+                await manager._status_callback("unauthorized_blocked", block_reason)
+            return
+
+        if should_notify:
+            await notify_error(manager, "unauthorized")
+        else:
+            await manager.async_stop()
         if manager._status_callback:
-            await manager._status_callback("unauthorized_blocked", block_reason)
-        return
-
-    if should_notify:
-        await notify_error(manager, "unauthorized")
-    else:
-        await manager.async_stop()
-    if manager._status_callback:
-        await manager._status_callback("unauthorized", "MQTT authentication failed")
+            await manager._status_callback("unauthorized", "MQTT authentication failed")
+    finally:
+        async with manager._unauthorized_lock:
+            manager._unauthorized_retry_in_progress = False
 
 
 async def notify_error(manager: CardataStreamManager, reason: str) -> None:

--- a/custom_components/cardata/stream_reconnect.py
+++ b/custom_components/cardata/stream_reconnect.py
@@ -60,12 +60,10 @@ async def async_reconnect(manager: CardataStreamManager) -> None:
             await manager._status_callback("connected", None)
         return
 
+    # Tear the old client down before looking at the circuit breaker. Giving up
+    # here without stopping it leaves a client we no longer track, and paho
+    # keeps its own network thread alive on the socket.
     try:
-        if manager._circuit_breaker.check():
-            if debug_enabled():
-                _LOGGER.debug("Skipping MQTT reconnect due to open circuit breaker")
-            return
-
         await manager._async_stop_locked()
     finally:
         manager._connect_lock.release()
@@ -76,6 +74,11 @@ async def async_reconnect(manager: CardataStreamManager) -> None:
     # guard will detect it.  Safe because the old client is already gone
     # (no more MQTT callbacks will check the flag).
     manager._intentional_disconnect = False
+
+    if manager._circuit_breaker.check():
+        if debug_enabled():
+            _LOGGER.debug("Skipping MQTT reconnect due to open circuit breaker")
+        return
 
     # Phase 2: Token refresh (no lock needed - client is stopped)
     # Skip token refresh when using a custom MQTT broker (no BMW auth needed)

--- a/fuzz/fuzz_mqtt_boundary.py
+++ b/fuzz/fuzz_mqtt_boundary.py
@@ -79,6 +79,7 @@ def _install_paho_stub() -> None:
     client.MQTTMessage = MQTTMessage
     client.MQTTv311 = 4
     client.MQTT_ERR_SUCCESS = 0
+    client.MQTT_ERR_NO_CONN = 4
     client.MQTT_ERR_CONN_REFUSED = 5
     client.MQTT_ERR_CONN_LOST = 7
     client.MQTT_ERR_KEEPALIVE = 16

--- a/fuzz/fuzz_mqtt_boundary.py
+++ b/fuzz/fuzz_mqtt_boundary.py
@@ -78,6 +78,12 @@ def _install_paho_stub() -> None:
     client.Client = Client
     client.MQTTMessage = MQTTMessage
     client.MQTTv311 = 4
+    client.MQTT_ERR_SUCCESS = 0
+    client.MQTT_ERR_CONN_REFUSED = 5
+    client.MQTT_ERR_CONN_LOST = 7
+    client.MQTT_ERR_KEEPALIVE = 16
+    client.error_string = lambda rc: f"Error {rc}."
+    client.connack_string = lambda rc: f"Connection result {rc}."
     mqtt.client = client
     paho.mqtt = mqtt
 


### PR DESCRIPTION
Fixes #443, plus a set of related faults found while tracing it.

## The problem

The report shows two things in one burst: frequent `rc=7` disconnects logged as "client inactivity", and reconnects refused with `Not authorized` while the cached token is still valid for 1000+ seconds.

**We never refreshed the rejected token.** `handle_stream_error` called `refresh_tokens_for_entry` with the default 300 second expiry buffer, while the proactive loop refreshes every 45 minutes against a one hour token. Between two refreshes the token always has 900 to 2700 seconds left, so the refresh short circuited, logged `Token was refreshed by another caller; skipping`, and the caller then reported "BMW credentials refreshed successfully after auth failure" and reconnected with the same rejected token. The recovery seen in the logs came from the delay in that path, not from new credentials.

**The disconnect reason table was the wrong table.** The `rc` handed to `on_disconnect` is a paho `MQTT_ERR_*` code, not a CONNACK code. So `7` (`MQTT_ERR_CONN_LOST`) was reported as "disconnected due to client inactivity", an idle timeout BMW never sent and the basis for the reporter's first hypothesis, while `4` (`MQTT_ERR_NO_CONN`) and `5` (`MQTT_ERR_CONN_REFUSED`) were read as authentication failures and pushed into the reauth path. `MQTT_ERR_KEEPALIVE` (16) had no case at all and warned as an unknown disconnect.

**paho was reconnecting alongside us.** `loop_start()` runs `loop_forever()`, and `reconnect_on_failure` defaults to true, so after a lost connection paho retried on its own schedule, ignoring our backoff, circuit breaker and token refresh. Both connect with the same client ID, the GCID, and BMW accepts one stream connection per account (#255), so the two attempts can refuse or displace each other.

## The change

One commit per fault:

- `0f22ec0` a `force` flag on `refresh_tokens_for_entry`, used where BMW has told us the credentials are not accepted, and for the manual refresh action where the user asked for new tokens
- `84dbfc7` say the token was still valid rather than blaming a concurrent caller
- `5654808` read disconnect codes as `MQTT_ERR_*`, and leave refusals to the connect callback, which already has the CONNACK code and picks the recovery
- `14c72b4` skip the five second wait for a disconnect acknowledgement when paho returns `MQTT_ERR_NO_CONN`, meaning the socket was already gone and no callback is coming
- `76ceba2` tear the client down before the circuit breaker aborts a reconnect, instead of abandoning a client we no longer track
- `5a4af79` `reconnect_on_failure=False`, so the integration is the only thing reconnecting
- `1081150` hold the unauthorized guard until the retry finishes, rather than clearing it inside the lock before any of the work
- `0ed1366` wait out the breaker cooldown instead of dropping the reconnect, since nothing else brings the stream back
- `749c752` when BMW refuses the stream with tokens it has just issued, report a connection conflict instead of asking for a reauthorisation that cannot help

Plus documentation in `80cb4e1` and `1f91850`.

## Testing

This was exercised through the fuzz harness stubs. Same harness against both trees:

```
rc=7  connection lost      -> async_reconnect, no auth path   (was: same)
rc=5  connection refused   -> left to the connect callback     (was: handle_unauthorized twice)
rc=4  client not connected -> async_reconnect                  (was: reauth path)
stop after connection loss -> 0.00s                            (was: 5.01s)
stop while connected       -> 5.01s, unchanged
re-entrant unauthorized    -> dropped, backoff bumped once     (was: recursed to RecursionError)
open circuit breaker       -> reconnects after the cooldown    (was: never)
entry unloaded mid wait    -> gives up without starting a client
```

Conflict handling, driving the real `handle_stream_error`:

```
conflict (fresh token still refused)  1 refresh, notified once, keeps retrying, no reauth
stale token (fresh token connects)    refreshes and reconnects, never flagged
network fault (no CONNACK)            never misdiagnosed as a refusal
other client leaves                   next attempt connects, verdict dropped, notice dismissed
refresh token later expires           reauth flow correctly reached
```

Connection attempts under a sustained conflict are unchanged at 20 per 20 refusals, with one token refresh rather than none.

`ruff check`, `ruff format --check` and `mypy` are clean over `custom_components/cardata`. The test suite is unchanged at 15 failed and 211 passed, the failures being the pre-existing stale ones in `tests/test_stream.py`. All 13 fuzz harnesses still import, and `fuzz/fuzz_mqtt_boundary.py` gained the paho error code constants the new code uses.

## Worth knowing

`reconnect_on_failure=False` also disables paho's automatic downgrade from MQTT 3.1.1 to 3.1 when a broker refuses the protocol version. BMW requires 3.1.1 and no custom broker report in this repo has ever mentioned it, but a broker speaking only 3.1 would now fail with a clear `Incorrect protocol version` instead of silently downgrading.
