### PR TITLE
Corrections to the window and sunroof binary sensors

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Run unit and mocked setup tests
         env:
           PYTHONPATH: "."
-        run: pytest -q tests/test_config_flow.py tests/test_soc_wiring.py tests/test_soc_phase_inference.py
+        run: pytest -q tests/test_config_flow.py tests/test_soc_wiring.py tests/test_soc_phase_inference.py tests/test_opening_binary_sensors.py

--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Configure it in Home Assistant via **Settings -> Devices & Services -> BMW CarDa
 - Each VIN becomes a device in HA (`VIN` pulled from CarData).
 - Sensors/binary sensors are auto-created and named from descriptors (e.g. `Cabin Door Row1 Driver Is Open`).
 - The device tracker (location entity) is restored from the entity registry on restart, so it keeps its last known position even before MQTT data arrives.
+- The windows and the sunroof get a binary sensor with the `window` device class, which reports open or closed and can drive a `window.opened` trigger. The string sensor that reports the raw BMW enum (`CLOSED`, `INTERMEDIATE`, `OPEN`) is still there but hidden on a new install, so unhide it from the entity settings if you want the intermediate position.
 - Additional attributes include the source timestamp.
 - All numeric sensors declare `suggested_display_precision`, so unit conversions (e.g. km to miles) display clean rounded values in standard HA cards and the built-in vehicle card. You can override the display unit per entity via the gear icon in the entity settings, or switch your HA unit system to imperial for a global change.
 

--- a/custom_components/cardata/binary_sensor.py
+++ b/custom_components/cardata/binary_sensor.py
@@ -278,13 +278,6 @@ class CardataBinarySensor(CardataEntity, RestoreEntity, BinarySensorEntity):
             else:
                 return "mdi:circle"
 
-        # Window and sunroof openings - dynamic icon based on state
-        if self.descriptor and self.descriptor in OPENING_STATUS_DESCRIPTORS:
-            is_open = getattr(self, "_attr_is_on", False)
-            if is_open:
-                return "mdi:car-door"
-            return "mdi:car-door-lock"
-
         # Motion sensors - dynamic icon based on state
         if self.descriptor and self.descriptor in MOTION_DESCRIPTORS:
             is_moving = getattr(self, "_attr_is_on", False)

--- a/custom_components/cardata/binary_sensor.py
+++ b/custom_components/cardata/binary_sensor.py
@@ -43,7 +43,7 @@ from homeassistant.helpers.entity_registry import (
 )
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .const import DOMAIN
+from .const import DOMAIN, OPENING_STATUS_DESCRIPTORS
 from .coordinator import CardataCoordinator
 from .entity import CardataEntity
 from .runtime import CardataRuntimeData
@@ -71,17 +71,6 @@ DOOR_DESCRIPTORS = (
 WINDOW_BOOL_DESCRIPTORS = ("vehicle.body.trunk.window.isOpen",)
 
 MOTION_DESCRIPTORS = ("vehicle.isMoving",)
-
-# Windows and the sunroof report an enum string rather than a boolean, so they
-# arrive on the sensor platform. They get a binary sensor in addition to it.
-OPENING_STATUS_DESCRIPTORS = {
-    "vehicle.cabin.window.row1.driver.status": BinarySensorDeviceClass.WINDOW,
-    "vehicle.cabin.window.row1.passenger.status": BinarySensorDeviceClass.WINDOW,
-    "vehicle.cabin.window.row2.driver.status": BinarySensorDeviceClass.WINDOW,
-    "vehicle.cabin.window.row2.passenger.status": BinarySensorDeviceClass.WINDOW,
-    # Home Assistant has no trigger integration for the opening device class.
-    "vehicle.cabin.sunroof.status": BinarySensorDeviceClass.WINDOW,
-}
 
 # The string sensor keeps the catalogue title, so the binary sensor needs its own.
 OPENING_STATUS_TITLES = {
@@ -156,7 +145,9 @@ class CardataBinarySensor(CardataEntity, RestoreEntity, BinarySensorEntity):
         elif descriptor in WINDOW_BOOL_DESCRIPTORS:
             self._attr_device_class = BinarySensorDeviceClass.WINDOW
         elif descriptor in OPENING_STATUS_DESCRIPTORS:
-            self._attr_device_class = OPENING_STATUS_DESCRIPTORS[descriptor]
+            # The sunroof is a window too: Home Assistant has no trigger
+            # integration for the opening device class.
+            self._attr_device_class = BinarySensorDeviceClass.WINDOW
             self._attr_unique_id = f"{vin}_{descriptor}{OPENING_UNIQUE_ID_SUFFIX}"
 
     def _format_name(self) -> str:

--- a/custom_components/cardata/binary_sensor.py
+++ b/custom_components/cardata/binary_sensor.py
@@ -100,6 +100,10 @@ OPENING_UNIQUE_ID_SUFFIX = "_open"
 OPENING_CLOSED_VALUES = frozenset({"CLOSED"})
 OPENING_OPEN_VALUES = frozenset({"OPEN", "INTERMEDIATE"})
 
+# BMW types the tailgate window as a boolean but documents the same value range
+# as the windows, so it can turn up in either form.
+OPENING_VALUE_DESCRIPTORS = frozenset(OPENING_STATUS_DESCRIPTORS) | frozenset(WINDOW_BOOL_DESCRIPTORS)
+
 
 def opening_status_to_bool(value: object) -> bool | None:
     """Map a BMW opening enum string onto a binary sensor state.
@@ -120,10 +124,10 @@ def opening_status_to_bool(value: object) -> bool | None:
 
 def coerce_binary_value(descriptor: str, value: object) -> bool | None:
     """Return the boolean a binary sensor must show, or None if unusable."""
-    if descriptor in OPENING_STATUS_DESCRIPTORS:
-        return opening_status_to_bool(value)
     if isinstance(value, bool):
         return value
+    if descriptor in OPENING_VALUE_DESCRIPTORS:
+        return opening_status_to_bool(value)
     return None
 
 
@@ -238,7 +242,7 @@ class CardataBinarySensor(CardataEntity, RestoreEntity, BinarySensorEntity):
             return
 
         new_value = coerce_binary_value(descriptor, state.value)
-        if new_value is None and descriptor not in OPENING_STATUS_DESCRIPTORS:
+        if new_value is None and descriptor not in OPENING_VALUE_DESCRIPTORS:
             # A value that is neither a boolean nor an opening enum belongs to
             # the sensor platform, so leave this entity as it is.
             return

--- a/custom_components/cardata/binary_sensor.py
+++ b/custom_components/cardata/binary_sensor.py
@@ -104,7 +104,9 @@ OPENING_OPEN_VALUES = frozenset({"OPEN", "INTERMEDIATE"})
 def opening_status_to_bool(value: object) -> bool | None:
     """Map a BMW opening enum string onto a binary sensor state.
 
-    Unrecognised values return None, which leaves the sensor unchanged.
+    BMW documents CLOSED, INTERMEDIATE, OPEN and INVALID for these
+    descriptors. INVALID and anything unrecognised return None, which the
+    sensor shows as unknown rather than as a guess at open or closed.
     """
     if not isinstance(value, str):
         return None
@@ -137,6 +139,7 @@ class CardataBinarySensor(CardataEntity, RestoreEntity, BinarySensorEntity):
     """Binary sensor for boolean telematic data."""
 
     _attr_should_poll = False
+    _attr_is_on: bool | None = None
 
     def __init__(self, coordinator: CardataCoordinator, vin: str, descriptor: str) -> None:
         super().__init__(coordinator, vin, descriptor)
@@ -235,7 +238,9 @@ class CardataBinarySensor(CardataEntity, RestoreEntity, BinarySensorEntity):
             return
 
         new_value = coerce_binary_value(descriptor, state.value)
-        if new_value is None:
+        if new_value is None and descriptor not in OPENING_STATUS_DESCRIPTORS:
+            # A value that is neither a boolean nor an opening enum belongs to
+            # the sensor platform, so leave this entity as it is.
             return
 
         # SMART FILTERING: Check if sensor's current state differs from new value

--- a/custom_components/cardata/binary_sensor.py
+++ b/custom_components/cardata/binary_sensor.py
@@ -92,6 +92,11 @@ OPENING_STATUS_TITLES = {
     "vehicle.cabin.sunroof.status": "Sunroof open",
 }
 
+# The string sensor already owns "{vin}_{descriptor}", and frontend_cards maps a
+# unique_id to an entity_id without looking at the domain, so a shared id would
+# hand the vehicle card's window lookups to the binary sensor.
+OPENING_UNIQUE_ID_SUFFIX = "_open"
+
 OPENING_CLOSED_VALUES = frozenset({"CLOSED"})
 OPENING_OPEN_VALUES = frozenset({"OPEN", "INTERMEDIATE"})
 
@@ -120,6 +125,14 @@ def coerce_binary_value(descriptor: str, value: object) -> bool | None:
     return None
 
 
+def descriptor_from_unique_id(unique_id_tail: str) -> str:
+    """Return the descriptor the tail of a binary sensor unique_id refers to."""
+    candidate = unique_id_tail.removesuffix(OPENING_UNIQUE_ID_SUFFIX)
+    if candidate in OPENING_STATUS_DESCRIPTORS:
+        return candidate
+    return unique_id_tail
+
+
 class CardataBinarySensor(CardataEntity, RestoreEntity, BinarySensorEntity):
     """Binary sensor for boolean telematic data."""
 
@@ -137,6 +150,7 @@ class CardataBinarySensor(CardataEntity, RestoreEntity, BinarySensorEntity):
             self._attr_device_class = BinarySensorDeviceClass.WINDOW
         elif descriptor in OPENING_STATUS_DESCRIPTORS:
             self._attr_device_class = OPENING_STATUS_DESCRIPTORS[descriptor]
+            self._attr_unique_id = f"{vin}_{descriptor}{OPENING_UNIQUE_ID_SUFFIX}"
 
     def _format_name(self) -> str:
         """Prefer the binary-specific title for derived opening sensors."""
@@ -352,7 +366,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             continue
 
         vin, descriptor = unique_id.split("_", 1)
-        ensure_entity(vin, descriptor, assume_binary=True)
+        ensure_entity(vin, descriptor_from_unique_id(descriptor), assume_binary=True)
 
     # Add binary sensors from coordinator state
     for vin, descriptor in coordinator.iter_descriptors(binary=True):

--- a/custom_components/cardata/binary_sensor.py
+++ b/custom_components/cardata/binary_sensor.py
@@ -358,7 +358,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     entity_registry = async_get(hass)
 
     for entity_entry in async_entries_for_config_entry(entity_registry, entry.entry_id):
-        if entity_entry.domain != "binary_sensor" or entity_entry.disabled_by is not None:
+        if entity_entry.domain not in ("binary_sensor", "sensor") or entity_entry.disabled_by is not None:
             continue
 
         unique_id = entity_entry.unique_id
@@ -366,6 +366,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             continue
 
         vin, descriptor = unique_id.split("_", 1)
+
+        if entity_entry.domain == "sensor":
+            # An install that predates these binary sensors has no binary_sensor
+            # entry to restore from, and coordinator.data is still empty this
+            # early on a reload, so the string sensor is the only trace an
+            # opening descriptor leaves behind.
+            if descriptor in OPENING_STATUS_DESCRIPTORS:
+                ensure_entity(vin, descriptor, assume_binary=True)
+            continue
+
         ensure_entity(vin, descriptor_from_unique_id(descriptor), assume_binary=True)
 
     # Add binary sensors from coordinator state

--- a/custom_components/cardata/const.py
+++ b/custom_components/cardata/const.py
@@ -68,14 +68,20 @@ LOCATION_LONGITUDE_DESCRIPTOR = "vehicle.cabin.infotainment.navigation.currentLo
 LOCATION_HEADING_DESCRIPTOR = "vehicle.cabin.infotainment.navigation.currentLocation.heading"
 LOCATION_ALTITUDE_DESCRIPTOR = "vehicle.cabin.infotainment.navigation.currentLocation.altitude"
 
-# Window descriptors for sensor icons
-WINDOW_DESCRIPTORS = (
+CABIN_WINDOW_STATUS_DESCRIPTORS = (
     "vehicle.cabin.window.row1.driver.status",
     "vehicle.cabin.window.row1.passenger.status",
     "vehicle.cabin.window.row2.driver.status",
     "vehicle.cabin.window.row2.passenger.status",
-    "vehicle.body.trunk.window.isOpen",
 )
+
+# Windows and the sunroof report an enum string, so they land on the sensor
+# platform. The binary sensor platform derives an open/closed entity from each
+# one and the string sensor steps out of the way.
+OPENING_STATUS_DESCRIPTORS = CABIN_WINDOW_STATUS_DESCRIPTORS + ("vehicle.cabin.sunroof.status",)
+
+# Window descriptors for sensor icons
+WINDOW_DESCRIPTORS = CABIN_WINDOW_STATUS_DESCRIPTORS + ("vehicle.body.trunk.window.isOpen",)
 
 # Battery descriptors for device class detection
 BATTERY_DESCRIPTORS = {

--- a/custom_components/cardata/sensor.py
+++ b/custom_components/cardata/sensor.py
@@ -62,6 +62,7 @@ from .const import (
     LOCATION_LATITUDE_DESCRIPTOR,
     LOCATION_LONGITUDE_DESCRIPTOR,
     MAGIC_SOC_DESCRIPTOR,
+    OPENING_STATUS_DESCRIPTORS,
     PREDICTED_SOC_DESCRIPTOR,
     WINDOW_DESCRIPTORS,
 )
@@ -105,6 +106,14 @@ class CardataSensor(CardataEntity, RestoreEntity, SensorEntity):
             LOCATION_HEADING_DESCRIPTOR,
         ):
             self._attr_entity_registry_enabled_default = False
+
+        # The binary sensor built from this descriptor answers the open or
+        # closed question most people have, so the enum string starts hidden on
+        # a fresh install. It keeps its state, so the vehicle card and any
+        # automation reading it carry on working, and it can be unhidden from
+        # the entity settings.
+        if descriptor in OPENING_STATUS_DESCRIPTORS:
+            self._attr_entity_registry_visible_default = False
 
         if descriptor in (PREDICTED_SOC_DESCRIPTOR, MAGIC_SOC_DESCRIPTOR):
             self._attr_suggested_display_precision = 1

--- a/tests/test_opening_binary_sensors.py
+++ b/tests/test_opening_binary_sensors.py
@@ -32,13 +32,35 @@ from custom_components.cardata.binary_sensor import (
     OPENING_STATUS_DESCRIPTORS,
     OPENING_STATUS_TITLES,
     OPENING_UNIQUE_ID_SUFFIX,
+    CardataBinarySensor,
     coerce_binary_value,
     descriptor_from_unique_id,
     opening_status_to_bool,
 )
+from custom_components.cardata.descriptor_state import DescriptorState
 
 WINDOW_DESCRIPTOR = "vehicle.cabin.window.row1.driver.status"
 DOOR_DESCRIPTOR = "vehicle.cabin.door.row1.driver.isOpen"
+VIN = "WBA00000000000001"
+
+
+class FakeCoordinator:
+    """The slice of the coordinator a binary sensor reads from."""
+
+    def __init__(self) -> None:
+        self.device_metadata: dict[str, dict[str, str]] = {}
+        self.names: dict[str, str] = {}
+        self.value: object = None
+
+    def get_state(self, vin: str, descriptor: str) -> DescriptorState:
+        return DescriptorState(value=self.value, unit=None, timestamp=None)
+
+
+class OfflineSensor(CardataBinarySensor):
+    """A sensor that skips the Home Assistant state write."""
+
+    def schedule_update_ha_state(self, force_refresh: bool = False) -> None:
+        return None
 
 
 class TestOpeningStatusToBool:
@@ -89,6 +111,36 @@ class TestCoerceBinaryValue:
 
     def test_unknown_descriptor_rejects_string(self):
         assert coerce_binary_value("vehicle.something.else", "OPEN") is None
+
+
+class TestUnusableValue:
+    """Tests for what an opening sensor shows when the value is not usable."""
+
+    def test_invalid_clears_a_known_state(self):
+        """Holding the last value would contradict the string sensor."""
+        coordinator = FakeCoordinator()
+        sensor = OfflineSensor(coordinator, VIN, WINDOW_DESCRIPTOR)
+
+        coordinator.value = "OPEN"
+        sensor._handle_update(VIN, WINDOW_DESCRIPTOR)
+        assert sensor.is_on is True
+
+        coordinator.value = "INVALID"
+        sensor._handle_update(VIN, WINDOW_DESCRIPTOR)
+        assert sensor.is_on is None
+
+    def test_boolean_descriptor_keeps_its_value(self):
+        """Only the opening descriptors change behaviour here."""
+        coordinator = FakeCoordinator()
+        sensor = OfflineSensor(coordinator, VIN, DOOR_DESCRIPTOR)
+
+        coordinator.value = True
+        sensor._handle_update(VIN, DOOR_DESCRIPTOR)
+        assert sensor.is_on is True
+
+        coordinator.value = "nonsense"
+        sensor._handle_update(VIN, DOOR_DESCRIPTOR)
+        assert sensor.is_on is True
 
 
 class TestUniqueIdSuffix:

--- a/tests/test_opening_binary_sensors.py
+++ b/tests/test_opening_binary_sensors.py
@@ -177,7 +177,13 @@ class TestOpeningDescriptorTables:
         titles = list(OPENING_STATUS_TITLES.values())
         assert len(titles) == len(set(titles))
 
-    def test_every_descriptor_is_reachable_from_a_trigger(self):
-        """Home Assistant ships trigger integrations for window and door, but not opening."""
-        reachable = {BinarySensorDeviceClass.WINDOW, BinarySensorDeviceClass.DOOR}
-        assert set(OPENING_STATUS_DESCRIPTORS.values()) <= reachable
+    def test_every_descriptor_uses_a_class_with_a_trigger_integration(self):
+        """Home Assistant ships a window and a door trigger integration, but no opening one.
+
+        binary_sensor's device triggers do cover the opening device class, so
+        the point is narrower than it looks: a window.opened trigger targets
+        binary_sensor entities classified as window, and nothing targets one
+        classified as opening.
+        """
+        with_trigger_integration = {BinarySensorDeviceClass.WINDOW, BinarySensorDeviceClass.DOOR}
+        assert set(OPENING_STATUS_DESCRIPTORS.values()) <= with_trigger_integration

--- a/tests/test_opening_binary_sensors.py
+++ b/tests/test_opening_binary_sensors.py
@@ -41,6 +41,7 @@ from custom_components.cardata.descriptor_state import DescriptorState
 
 WINDOW_DESCRIPTOR = "vehicle.cabin.window.row1.driver.status"
 DOOR_DESCRIPTOR = "vehicle.cabin.door.row1.driver.isOpen"
+TAILGATE_DESCRIPTOR = "vehicle.body.trunk.window.isOpen"
 VIN = "WBA00000000000001"
 
 
@@ -108,6 +109,13 @@ class TestCoerceBinaryValue:
     def test_boolean_descriptor_rejects_string(self):
         """Existing behaviour is preserved: non-opening descriptors stay boolean-only."""
         assert coerce_binary_value(DOOR_DESCRIPTOR, "OPEN") is None
+
+    def test_tailgate_window_takes_either_form(self):
+        """BMW types it boolean but documents the window value range for it."""
+        assert coerce_binary_value(TAILGATE_DESCRIPTOR, True) is True
+        assert coerce_binary_value(TAILGATE_DESCRIPTOR, "OPEN") is True
+        assert coerce_binary_value(TAILGATE_DESCRIPTOR, "CLOSED") is False
+        assert coerce_binary_value(TAILGATE_DESCRIPTOR, "INVALID") is None
 
     def test_unknown_descriptor_rejects_string(self):
         assert coerce_binary_value("vehicle.something.else", "OPEN") is None

--- a/tests/test_opening_binary_sensors.py
+++ b/tests/test_opening_binary_sensors.py
@@ -29,7 +29,6 @@ import pytest
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 
 from custom_components.cardata.binary_sensor import (
-    OPENING_STATUS_DESCRIPTORS,
     OPENING_STATUS_TITLES,
     OPENING_UNIQUE_ID_SUFFIX,
     CardataBinarySensor,
@@ -37,7 +36,9 @@ from custom_components.cardata.binary_sensor import (
     descriptor_from_unique_id,
     opening_status_to_bool,
 )
+from custom_components.cardata.const import OPENING_STATUS_DESCRIPTORS
 from custom_components.cardata.descriptor_state import DescriptorState
+from custom_components.cardata.sensor import CardataSensor
 
 WINDOW_DESCRIPTOR = "vehicle.cabin.window.row1.driver.status"
 DOOR_DESCRIPTOR = "vehicle.cabin.door.row1.driver.isOpen"
@@ -186,4 +187,33 @@ class TestOpeningDescriptorTables:
         classified as opening.
         """
         with_trigger_integration = {BinarySensorDeviceClass.WINDOW, BinarySensorDeviceClass.DOOR}
-        assert set(OPENING_STATUS_DESCRIPTORS.values()) <= with_trigger_integration
+        coordinator = FakeCoordinator()
+        for descriptor in OPENING_STATUS_DESCRIPTORS:
+            sensor = OfflineSensor(coordinator, VIN, descriptor)
+            assert sensor.device_class in with_trigger_integration
+
+
+class TestRegistryDefaults:
+    """Tests for which of the two entities a fresh install shows."""
+
+    def test_derived_sensor_is_shown(self):
+        """It is the one that answers open or closed, so it is the one on the device page."""
+        coordinator = FakeCoordinator()
+        for descriptor in OPENING_STATUS_DESCRIPTORS:
+            sensor = OfflineSensor(coordinator, VIN, descriptor)
+            assert sensor.entity_registry_enabled_default is True
+            assert sensor.entity_registry_visible_default is True
+
+    def test_string_sensor_is_hidden(self):
+        """Hidden, not disabled: it keeps its state for the vehicle card and for automations."""
+        coordinator = FakeCoordinator()
+        for descriptor in OPENING_STATUS_DESCRIPTORS:
+            sensor = CardataSensor(coordinator, VIN, descriptor)
+            assert sensor.entity_registry_visible_default is False
+            assert sensor.entity_registry_enabled_default is True
+
+    def test_other_string_sensors_are_left_alone(self):
+        """Only the descriptors with a binary counterpart step out of the way."""
+        coordinator = FakeCoordinator()
+        sensor = CardataSensor(coordinator, VIN, TAILGATE_DESCRIPTOR)
+        assert sensor.entity_registry_visible_default is True

--- a/tests/test_opening_binary_sensors.py
+++ b/tests/test_opening_binary_sensors.py
@@ -31,7 +31,9 @@ from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from custom_components.cardata.binary_sensor import (
     OPENING_STATUS_DESCRIPTORS,
     OPENING_STATUS_TITLES,
+    OPENING_UNIQUE_ID_SUFFIX,
     coerce_binary_value,
+    descriptor_from_unique_id,
     opening_status_to_bool,
 )
 
@@ -87,6 +89,21 @@ class TestCoerceBinaryValue:
 
     def test_unknown_descriptor_rejects_string(self):
         assert coerce_binary_value("vehicle.something.else", "OPEN") is None
+
+
+class TestUniqueIdSuffix:
+    """Tests for the unique_id the derived sensors carry."""
+
+    def test_suffix_maps_back_to_the_descriptor(self):
+        for descriptor in OPENING_STATUS_DESCRIPTORS:
+            assert descriptor_from_unique_id(f"{descriptor}{OPENING_UNIQUE_ID_SUFFIX}") == descriptor
+
+    def test_boolean_descriptor_is_left_alone(self):
+        assert descriptor_from_unique_id(DOOR_DESCRIPTOR) == DOOR_DESCRIPTOR
+
+    def test_unsuffixed_opening_descriptor_is_left_alone(self):
+        """Only the suffixed form belongs to a derived sensor."""
+        assert descriptor_from_unique_id(WINDOW_DESCRIPTOR) == WINDOW_DESCRIPTOR
 
 
 class TestOpeningDescriptorTables:


### PR DESCRIPTION
Follow-up to #436. These are the corrections I had opened against the feature branch (pszypowicz/bmw-cardata-ha#3); it was merged before they landed, so they come as their own PR against main.

**A unique_id of its own.** The derived binary sensor took `{vin}_{descriptor}`, the id the enum string sensor already owns. `frontend_cards._build_unique_id_map()` keys on unique_id without looking at the domain, so the vehicle card's window lookups could end up on the binary sensor. The derived one now appends `_open`.

**Created on installs that already exist.** The restore loop only walked `binary_sensor` registry entries, and `coordinator.data` is still empty that early in a reload, so on an existing install the new entities appeared only once BMW next reported a window change, which for a parked car can be a long wait. The loop now also reads the `sensor` entries for the opening descriptors.

**Unknown rather than a stale reading.** BMW documents INVALID alongside CLOSED, INTERMEDIATE and OPEN. `_handle_update` returned early on an unmapped value, so the sensor kept whatever it showed before. The opening descriptors now go to unknown.

**The tailgate window in either form.** `vehicle.body.trunk.window.isOpen` is typed as a boolean, but the catalogue gives it the same value range as the windows, so it can arrive as either.

**Icons left to the device class.** The openings branch in `icon` returned car door icons; the window device class already picks the right open and closed icon.

**The test file runs.** `tests/test_opening_binary_sensors.py` is in the tree but `integration-tests.yml` never runs it. It is on the list now, and covers each of the above.

**Visibility**, as settled on the fork PR: the derived binary sensors are created enabled and the enum string sensors start hidden, because open or closed is the answer nearly everyone wants. Hidden rather than disabled, so the state stays available to the card and to an automation reading INTERMEDIATE. Installs that already show these sensors are untouched, since a registry default only applies the first time an entity is seen.
