### PR TITLE
Fix the container fuzzer and run the harnesses in the smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,16 +110,20 @@ jobs:
         run: pip install -r requirements-fuzz.txt
 
       # The nightly fuzzing only notices a broken harness at 01:00, and a
-      # harness that dies at import wastes a whole matrix job. Import each one
-      # here instead. The glob must match the one the fuzzing workflow uses to
-      # build its matrix. run_name keeps main() from starting a real fuzz run,
-      # and each harness needs its own process because the homeassistant stub
-      # installers skip their work when the module is already imported.
-      - name: Import every fuzz harness
+      # harness that dies wastes a whole matrix job. Give each one a five
+      # second run here instead. Importing alone used to be enough for the
+      # stale homeassistant stubs, but it leaves TestOneInput uncalled, so a
+      # harness reaching for production code that has since been deleted still
+      # got through. The glob must match the one the fuzzing workflow uses to
+      # build its matrix, FUZZ_MAX_TIME is the budget every harness reads, and
+      # -timeout mirrors the nightly so one slow input cannot stall the job.
+      - name: Fuzz every harness briefly
+        env:
+          FUZZ_MAX_TIME: "5"
         run: |
           status=0
           for harness in fuzz/fuzz_*.py; do
             echo "== $harness"
-            python -c "import runpy, sys; runpy.run_path(sys.argv[1], run_name='smoke')" "$harness" || status=1
+            python "$harness" -timeout=30 || status=1
           done
           exit $status

--- a/fuzz/fuzz_container_matching.py
+++ b/fuzz/fuzz_container_matching.py
@@ -201,14 +201,10 @@ def TestOneInput(data: bytes) -> None:
     payload = _consume_payload_shape(fdp)
     containers = api_parsing.extract_container_items(payload)
 
-    manager = object.__new__(container_module.CardataContainerManager)
-    # An empty signature is a state production cannot reach, since __init__
-    # always stores a sha1 hexdigest, so compute one either way.
-    desired = list(const.HV_BATTERY_DESCRIPTORS) if fdp.ConsumeBool() else str_only
-    manager._descriptor_signature = container_module.CardataContainerManager.compute_signature(desired)
+    manager = container_module.CardataContainerManager(session=None, entry_id="fuzz")
 
     for container in containers:
-        manager._matches_hv_container(container)
+        manager._matches_hv_container_name_purpose(container)
 
 
 def main() -> None:


### PR DESCRIPTION
Last night's fuzzing run failed. `fuzz_container_matching` died fifteen seconds in, and it is the harness at fault rather than the integration.

## The problem

```
AttributeError: 'CardataContainerManager' object has no attribute '_matches_hv_container'
  File "fuzz/fuzz_container_matching.py", line 211, in TestOneInput
```

`_matches_hv_container` was the strict match: name, purpose and descriptor signature. It went out with `async_ensure_hv_container` in #451, since nothing called either any more, leaving the loose `_matches_hv_container_name_purpose` that `async_reset_hv_container` uses. The fuzzer kept calling the strict one, and about a third of the inputs I generated reach that line, so the nightly would have failed every night from here on.

CI had nothing to say about it, because `fuzz-smoke` only imported each harness:

```
python -c "import runpy, sys; runpy.run_path(sys.argv[1], run_name='smoke')" "$harness"
```

Under a name that is not `__main__`, `main()` never starts, so `TestOneInput` is never fed anything and a stale call inside it stays invisible. The step catches a harness that dies at import, which is how the hand-rolled `homeassistant` stubs usually break, and nothing else. Both CI runs that followed the deletion were green.

## The change

Two commits.

**The fuzzer calls the matcher that exists.** That matcher ignores the descriptor signature, so the hand-set `_descriptor_signature` and the `object.__new__` that existed to allow it both go, and the manager is built the normal way:

```diff
-    manager = object.__new__(container_module.CardataContainerManager)
-    # An empty signature is a state production cannot reach, since __init__
-    # always stores a sha1 hexdigest, so compute one either way.
-    desired = list(const.HV_BATTERY_DESCRIPTORS) if fdp.ConsumeBool() else str_only
-    manager._descriptor_signature = container_module.CardataContainerManager.compute_signature(desired)
+    manager = container_module.CardataContainerManager(session=None, entry_id="fuzz")
 
     for container in containers:
-        manager._matches_hv_container(container)
+        manager._matches_hv_container_name_purpose(container)
```

Signature coverage is unchanged, since `compute_signature` is still exercised at the top of `TestOneInput` with a fuzzer-built descriptor list.

**The smoke step runs each harness for five seconds** rather than importing it:

```diff
-      - name: Import every fuzz harness
+      - name: Fuzz every harness briefly
+        env:
+          FUZZ_MAX_TIME: "5"
         run: |
           status=0
           for harness in fuzz/fuzz_*.py; do
             echo "== $harness"
-            python -c "import runpy, sys; runpy.run_path(sys.argv[1], run_name='smoke')" "$harness" || status=1
+            python "$harness" -timeout=30 || status=1
           done
           exit $status
```

`FUZZ_MAX_TIME` is the budget every harness already reads, so the five seconds needs no new plumbing, and `-timeout` mirrors the nightly so one slow input cannot stall the job. A real run subsumes the import check, so nothing is lost.

## Testing

The new step on this branch: thirteen harnesses, about **1.35 million executions in 1m54s**, all green. `fuzz_container_matching` alone managed 242236 of them.

To check the guard actually catches this rather than only looking as though it would, I put the CI change on top of `main` with the harness left broken. `fuzz-smoke` went red on the same `AttributeError` three and a half seconds into that harness, so it would have caught the break on the push that caused it.

On the harness itself, 20000 generated inputs through the fixed `TestOneInput` produce no failures, against 6769 `AttributeError`s from the same sweep before the fix. Every harness runs to completion as `__main__` and hands libFuzzer `-timeout=30 -max_total_time=5`. None carries an `atexit` hook or a reach assertion, so a short run has nothing time dependent to trip over, and `fuzz_mqtt_boundary`, the one harness that skips `logging.disable`, pins `cardata.stream` to ERROR so it will not flood the log either.

`ruff check`, `ruff format` and `mypy` give identical output on the harness before and after the change. What they report is pre-existing, since `fuzz/` is not linted.

No integration code is touched.
