### PR TITLE
Connect on the loop's first pass and never keep a dead client

### DIFF
--- a/custom_components/cardata/stream.py
+++ b/custom_components/cardata/stream.py
@@ -163,7 +163,15 @@ class CardataStreamManager:
             except Exception as err:
                 _LOGGER.exception("Exception in MQTT async callback: %s", err)
 
-        future = asyncio.run_coroutine_threadsafe(coro, self.hass.loop)
+        try:
+            future = asyncio.run_coroutine_threadsafe(coro, self.hass.loop)
+        except RuntimeError as err:
+            # The loop is closed, which happens while Home Assistant shuts
+            # down. Letting this out would end the MQTT network thread.
+            coro.close()
+            if debug_enabled():
+                _LOGGER.debug("Event loop gone; dropping MQTT callback work: %s", err)
+            return
         future.add_done_callback(_done_callback)
 
     def _cancel_retry_threadsafe(self) -> None:
@@ -173,7 +181,7 @@ class CardataStreamManager:
         loop and has to be handed over rather than done here, the way every
         other callback on this thread hands its work over.
         """
-        self.hass.loop.call_soon_threadsafe(stream_reconnect.cancel_retry, self)
+        self._call_on_loop(stream_reconnect.cancel_retry, self)
 
     def _schedule_retry_threadsafe(self, delay: float) -> None:
         """Schedule a retry from the MQTT network thread.
@@ -181,7 +189,49 @@ class CardataStreamManager:
         Creating the task belongs to the loop, and doing it from here leaves
         it queued without waking the loop.
         """
-        self.hass.loop.call_soon_threadsafe(stream_reconnect.schedule_retry, self, delay)
+        self._call_on_loop(stream_reconnect.schedule_retry, self, delay)
+
+    def _call_on_loop(self, callback: Callable[..., Any], *args: Any) -> None:
+        """Hand a call to the event loop from the MQTT network thread.
+
+        The loop can already be closed when Home Assistant shuts down, and the
+        error that raises would leave the callback and end the network thread.
+        """
+        try:
+            self.hass.loop.call_soon_threadsafe(callback, *args)
+        except RuntimeError as err:
+            if debug_enabled():
+                _LOGGER.debug("Event loop gone; dropping MQTT callback work: %s", err)
+
+    def _guarded_callback(self, handler: Callable[..., None], name: str) -> Callable[..., None]:
+        """Keep a failing callback from taking the network thread with it.
+
+        paho logs what a callback lets through and re-raises it, which unwinds
+        its network loop and ends the thread. Nothing reports that, so the
+        manager would go on holding a client it believes is connected and
+        nothing would reconnect until the next token refresh. Fail the
+        connection instead and let the retry rebuild it. _handle_message keeps
+        its own guard, so a payload it cannot read never reaches this one.
+        """
+
+        def _run(client: mqtt.Client, *args: Any) -> None:
+            try:
+                handler(client, *args)
+            except Exception:
+                _LOGGER.exception("BMW MQTT %s callback failed; dropping the connection", name)
+                self._connection_state = ConnectionState.FAILED
+                self._safe_loop_stop(client)
+                self._client = None
+                if self._status_callback:
+                    self._run_coro_safe(
+                        cast(
+                            Coroutine[Any, Any, None],
+                            self._status_callback("connection_failed", f"MQTT {name} callback failed"),
+                        )
+                    )
+                self._schedule_retry_threadsafe(3)
+
+        return _run
 
     def _safe_loop_stop(self, client: mqtt.Client) -> None:
         """Safely stop the MQTT loop, handling any exceptions.
@@ -458,15 +508,18 @@ class CardataStreamManager:
             topic = f"{self._gcid}/+"
             client_id = self._gcid
 
-        # reconnect_on_failure stays default (True): it also gates paho's
-        # retry of a first connect that never gets a CONNACK. Disabled later
-        # in _handle_connect once we're actually connected instead.
+        # reconnect_on_failure=False: after a lost connection paho would run its
+        # own reconnect loop in the network thread, in parallel with ours and
+        # without the backoff, the circuit breaker or the token refresh. Both
+        # would then connect under the same client id, and the broker drops the
+        # older session whenever the newer one arrives.
         client = mqtt.Client(
             client_id=client_id,
             clean_session=True,
             userdata={"topic": topic},
             protocol=mqtt.MQTTv311,
             transport="tcp",
+            reconnect_on_failure=False,
         )
         if debug_enabled():
             _LOGGER.debug(
@@ -496,10 +549,10 @@ class CardataStreamManager:
                     len(self._password or ""),
                 )
 
-        client.on_connect = self._handle_connect
-        client.on_subscribe = self._handle_subscribe
-        client.on_message = self._handle_message
-        client.on_disconnect = self._handle_disconnect
+        client.on_connect = self._guarded_callback(self._handle_connect, "connect")
+        client.on_subscribe = self._guarded_callback(self._handle_subscribe, "subscribe")
+        client.on_message = self._guarded_callback(self._handle_message, "message")
+        client.on_disconnect = self._guarded_callback(self._handle_disconnect, "disconnect")
 
         if self._custom_broker:
             # Custom broker: configure TLS based on user setting
@@ -535,13 +588,17 @@ class CardataStreamManager:
         self._connect_event = threading.Event()
         self._connect_rc = None
 
-        # Start the network loop first (required for connect_async)
-        client.loop_start()
-        loop_started = True
+        loop_started = False
 
         try:
-            # Initiate async connection - actual connection happens in loop thread
+            # connect_async() only records where to connect; the network loop
+            # does the connecting on its first pass, so it has to be told
+            # before the loop starts. Started first, the loop finds no socket,
+            # gives up on the pass and, with paho's own reconnect turned off,
+            # never comes back.
             client.connect_async(self._host, self._port, keepalive=self._keepalive)
+            client.loop_start()
+            loop_started = True
 
             # Wait for on_connect callback to signal completion
             if not self._connect_event.wait(timeout=self._connect_timeout):
@@ -570,18 +627,19 @@ class CardataStreamManager:
                 _LOGGER.warning("BMW MQTT connection failed (entry %s): %s", self._entry_id, error_reason)
                 raise ConnectionError(f"MQTT connection failed: {error_reason}")
 
+            self._client = client
+
             # The broker can accept the connection and refuse the subscription
-            # straight after it, and when both answers arrive together the
-            # subscribe callback runs before this thread is scheduled again.
-            # It has already stopped the client and asked for a retry, so
-            # storing the client here would leave a dead one on record and the
-            # retry skips a manager that still holds one, leaving the stream
-            # down until the next token refresh.
+            # straight after it, and that callback runs on the network thread,
+            # so it can land either side of the line above. It stops the client
+            # and clears the field itself, so anything left here is a client
+            # nobody drives, and the retry it just asked for skips a manager
+            # that still holds one. Check after the store to cover both
+            # orderings.
             if self._connection_state is ConnectionState.FAILED:
+                self._client = None
                 raise ConnectionError("MQTT connection failed: subscription refused")
 
-            # Success - transfer ownership to self._client
-            self._client = client
             loop_started = False  # Loop now managed by self._client
 
         except Exception as err:
@@ -603,10 +661,6 @@ class CardataStreamManager:
 
         if rc == 0:
             self._connection_state = ConnectionState.CONNECTED
-            # Stop paho's own reconnect loop now that we're connected, so it
-            # can't race our reconnect/backoff/circuit-breaker after a drop.
-            # No public setter for this, only the constructor flag.
-            client._reconnect_on_failure = False
             # Circuit breaker success is recorded on the SUBACK grant, not here.
             # The broker can accept the connection and then refuse the
             # subscription, which would leave us connected but receiving nothing.

--- a/tests/test_stream_retry.py
+++ b/tests/test_stream_retry.py
@@ -138,3 +138,191 @@ def test_a_refused_subscription_is_not_stored_as_a_live_client() -> None:
         assert manager._connection_state is ConnectionState.FAILED
     finally:
         loop.close()
+
+
+def test_the_connect_target_is_set_before_the_network_loop_starts() -> None:
+    """paho does the connecting on the network loop's first pass.
+
+    A loop started before connect_async finds no socket, returns at once and,
+    with paho's own reconnect turned off, stops there. No CONNACK ever arrives
+    and every attempt runs into the connect timeout.
+    """
+    loop = asyncio.new_event_loop()
+    try:
+        hass = MagicMock()
+        hass.loop = loop
+
+        manager = CardataStreamManager(
+            hass=hass,
+            client_id="client",
+            gcid="gcid",
+            id_token="token",
+            host="localhost",
+            port=8883,
+            keepalive=30,
+        )
+
+        calls: list[str] = []
+
+        def fake_client(*_args, **kwargs):
+            client = MagicMock()
+            userdata = kwargs.get("userdata") or {}
+
+            def connect_async(_host, _port, keepalive=None):
+                calls.append("connect_async")
+
+            def loop_start():
+                calls.append("loop_start")
+                manager._handle_connect(client, userdata, {}, 0)
+
+            client.connect_async = connect_async
+            client.loop_start = loop_start
+            return client
+
+        with patch("custom_components.cardata.stream.mqtt.Client", side_effect=fake_client):
+            manager._start_client()
+
+        assert calls == ["connect_async", "loop_start"]
+        assert manager.client is not None
+    finally:
+        loop.close()
+
+
+def test_a_subscription_refused_as_the_client_is_stored_is_not_kept() -> None:
+    """The subscribe callback runs on the MQTT network thread.
+
+    It can land either side of the line that stores the client, and it clears
+    the field itself, so a store landing after it would put a stopped client
+    back on record and the retry it asked for skips a manager that still holds
+    one. The setter below lands it on the store itself.
+    """
+    loop = asyncio.new_event_loop()
+    try:
+        hass = MagicMock()
+        hass.loop = loop
+
+        class RacingManager(CardataStreamManager):
+            """Fires the refused SUBACK exactly as the client is stored."""
+
+            @property
+            def _client(self):
+                return self.__dict__.get("_stored_client")
+
+            @_client.setter
+            def _client(self, value):
+                if value is not None and self.__dict__.pop("_arm", False):
+                    self._handle_subscribe(value, {"topic": "gcid/+"}, 1, (0x80,))
+                self.__dict__["_stored_client"] = value
+
+        manager = RacingManager(
+            hass=hass,
+            client_id="client",
+            gcid="gcid",
+            id_token="token",
+            host="localhost",
+            port=8883,
+            keepalive=30,
+        )
+        manager.__dict__["_arm"] = True
+
+        def fake_client(*_args, **kwargs):
+            client = MagicMock()
+            userdata = kwargs.get("userdata") or {}
+
+            def loop_start():
+                manager._handle_connect(client, userdata, {}, 0)
+
+            client.loop_start = loop_start
+            return client
+
+        with patch("custom_components.cardata.stream.mqtt.Client", side_effect=fake_client):
+            with pytest.raises(ConnectionError):
+                manager._start_client()
+
+        assert manager.client is None
+        assert manager._connection_state is ConnectionState.FAILED
+    finally:
+        loop.close()
+
+
+def test_a_failing_callback_does_not_leave_the_stream_looking_connected() -> None:
+    """paho re-raises whatever a callback lets through.
+
+    That unwinds its network loop and ends the thread, and a manager still
+    holding a client in a connected state never reconnects, so the callback
+    has to bring the connection down instead of letting the error out.
+    """
+    loop = asyncio.new_event_loop()
+    try:
+        hass = MagicMock()
+        hass.loop = loop
+
+        manager = CardataStreamManager(
+            hass=hass,
+            client_id="client",
+            gcid="gcid",
+            id_token="token",
+            host="localhost",
+            port=8883,
+            keepalive=30,
+        )
+
+        created = []
+
+        def fake_client(*_args, **kwargs):
+            client = MagicMock()
+            userdata = kwargs.get("userdata") or {}
+
+            def loop_start():
+                manager._handle_connect(client, userdata, {}, 0)
+
+            client.loop_start = loop_start
+            created.append(client)
+            return client
+
+        with patch("custom_components.cardata.stream.mqtt.Client", side_effect=fake_client):
+            manager._start_client()
+
+        client = created[0]
+        assert manager.client is client
+
+        # The callback paho holds is the guarded one, and a userdata it cannot
+        # read stands in for anything going wrong inside the handler.
+        with patch.object(manager, "_schedule_retry_threadsafe") as schedule_retry:
+            client.on_connect(client, "not a dict", {}, 0)
+
+        assert manager.client is None
+        assert manager._connection_state is ConnectionState.FAILED
+        client.loop_stop.assert_called_once()
+        assert schedule_retry.call_count == 1
+    finally:
+        loop.close()
+
+
+def test_the_loop_handovers_survive_a_closed_event_loop() -> None:
+    """The callbacks hand their work to the event loop from the MQTT thread.
+
+    By the time Home Assistant has shut down that loop is closed, and the
+    error it raises would end the network thread on the way out.
+    """
+    loop = asyncio.new_event_loop()
+    loop.close()
+    hass = MagicMock()
+    hass.loop = loop
+
+    manager = CardataStreamManager(
+        hass=hass,
+        client_id="client",
+        gcid="gcid",
+        id_token="token",
+        host="localhost",
+        port=8883,
+        keepalive=30,
+    )
+
+    async def work() -> None:  # pragma: no cover - never scheduled
+        return None
+
+    manager._cancel_retry_threadsafe()
+    manager._schedule_retry_threadsafe(3)
+    manager._run_coro_safe(work())


### PR DESCRIPTION
The connect regression this branch started from was mine, from #444, and I am sorry about it. 7e6cb43 got the connection back on main. This branch fixes the ordering underneath it, and two other ways the same function can leave a stream nobody drives, both found while tracing the connect paths.

### The network loop was started before it was told where to connect

`_start_client` called `client.loop_start()` and only then `connect_async()`. paho does the connecting on the loop's first pass, and only when `connect_async()` has already recorded the target. Started first, the loop finds no socket, the `select()` on it fails and the pass returns, and with paho's own reconnect off the thread ends about a millisecond later, before `connect_async()` is even reached. That is the twenty second timeout reported in #451.

7e6cb43 restores the connection by leaving paho's reconnect enabled and clearing `client._reconnect_on_failure` from `_handle_connect` once a CONNACK arrives. That works. What it leaves in place is the ordering, so paho's retry is what connects us, and the time to connect is then exactly `reconnect_delay_set(min_delay=...)`: 5.03 s to bring one entry up and 15.08 s for three, since `_GLOBAL_MQTT_CONNECT_LOCK` serialises connects across entries, and every token refresh reconnect pays it again.

Handing `connect_async()` the target before starting the loop connects on the first pass instead: 0.04 s for one entry, 0.14 s for three. It also puts `reconnect_on_failure=False` back in the constructor, which is the documented argument for it, so the private attribute is not needed. The intent from #444 is unchanged, it is the same flag with the same value, set at construction rather than from the connect callback.

### A refused subscription can arrive as the client is stored

`_start_client` looked for a refused subscription one statement before it stored the client, and that callback runs on the network thread, so it can land between the two. It stops the client and clears `_client` itself, and the store then puts the stopped client straight back. `schedule_retry` skips a manager that still holds a client, so the retry it had just asked for does nothing and the stream stays down until the next token refresh. Storing first and looking after covers the callback landing on either side.

I forced that interleaving with a `_client` setter that fires the refused SUBACK on the store. Before, `_start_client` returns success, `_client` holds a stopped client and no further connect is made. After, it raises and the retry reconnects.

### A callback that raises takes the network thread with it

paho logs what a callback lets through and re-raises it unless `suppress_exceptions` is set, which we do not set. The error unwinds `loop_forever` and the thread ends, and since nothing reports that, we go on holding a client in a connected state. `_async_start_locked` returns early on CONNECTED, `_retry` skips because `_client` is set, and the post-bootstrap start in `lifecycle.py` skips for the same reason, so only the next token refresh brings the stream back.

The four callbacks now go through a guard that fails the connection instead: it logs, sets FAILED, stops the loop, clears `_client` and schedules a retry. `_handle_message` keeps its own guard, so a payload it cannot read still costs only that message.

The way a callback fails in practice is the hand-off to the event loop, `run_coroutine_threadsafe` and `call_soon_threadsafe`, which raise once the loop is closed at shutdown, and `CircuitBreaker.record_*` reaches the first of those through `_on_persist`. Both hand-offs now swallow that and log it, so the guard's own recovery cannot raise either.

### Testing

Four new tests in `tests/test_stream_retry.py`, each failing on main and passing here. I also ran the connect paths against a fake broker on localhost, on this branch and on main: first connect on the BMW and the custom broker branch, a dropped connection and the reconnect that follows, a refused CONNACK and recovery through a refreshed token, a refused SUBACK and the scheduled retry, a broker that never answers, a refused TCP connect, an open circuit breaker, a second `async_start` on a live stream, twenty concurrent connects, and `async_stop`. No zombie network threads in any of them.
