### PR TITLE
Create the learning reset buttons and capacity override for Neue Klasse cars

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Run unit and mocked setup tests
         env:
           PYTHONPATH: "."
-        run: pytest -q tests/test_config_flow.py tests/test_soc_wiring.py tests/test_soc_phase_inference.py tests/test_opening_binary_sensors.py tests/test_sensor_classes.py tests/test_charging_energy.py tests/test_mileage_guard.py tests/test_button_restore.py tests/test_stream_retry.py tests/test_container_id.py
+        run: pytest -q tests/test_config_flow.py tests/test_soc_wiring.py tests/test_soc_phase_inference.py tests/test_opening_binary_sensors.py tests/test_sensor_classes.py tests/test_charging_energy.py tests/test_mileage_guard.py tests/test_button_restore.py tests/test_number_capacity.py tests/test_stream_retry.py tests/test_container_id.py

--- a/custom_components/cardata/button.py
+++ b/custom_components/cardata/button.py
@@ -40,7 +40,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.entity_registry import async_entries_for_config_entry, async_get
 
-from .const import DESC_SOC_HEADER, DOMAIN, MAGIC_SOC_DESCRIPTOR
+from .const import DOMAIN, MAGIC_SOC_DESCRIPTOR, has_hv_battery
 from .utils import redact_vin
 
 if TYPE_CHECKING:
@@ -95,8 +95,7 @@ async def async_setup_entry(
 
     # Create reset buttons for each known EV/PHEV vehicle
     for vin, vehicle_data in coordinator.data.items():
-        # Check if this vehicle has HV battery (EV/PHEV)
-        if DESC_SOC_HEADER in vehicle_data:
+        if has_hv_battery(vehicle_data):
             create_learning_reset_buttons(vin)
 
     # Track consumption reset buttons created to prevent duplicates

--- a/custom_components/cardata/const.py
+++ b/custom_components/cardata/const.py
@@ -25,6 +25,8 @@
 
 """Constants for the BMW CarData integration."""
 
+from collections.abc import Container
+
 DOMAIN = "cardata"
 
 # Individual descriptor constants (used across 3+ files)
@@ -46,6 +48,7 @@ DESC_SOC_DISPLAYED = "vehicle.powertrain.electric.battery.stateOfCharge.displaye
 DESC_AVG_ELECTRIC_CONSUMPTION = "vehicle.drivetrain.avgElectricRangeConsumption"
 DESC_HVS_MAX_ENERGY = "vehicle.drivetrain.electricEngine.hvsMaxEnergyAbsolute"
 DESC_ENERGY_TO_FULL_CHARGE = "vehicle.drivetrain.electricEngine.charging.smeEnergyDeltaFullyCharged"
+
 
 # Lifetime counters BMW keeps for OBFCM reporting, in grid energy and in fuel.
 # They only ever climb, which is what makes them a cumulative total.
@@ -357,3 +360,14 @@ DAILY_FETCH_INTERVAL = 86400  # 24 hours
 
 # Key for storing deduplicated allowed VINs in entry data
 ALLOWED_VINS_KEY = "allowed_vins"
+
+
+def has_hv_battery(vehicle_state: Container[str]) -> bool:
+    """Return True when a vehicle reports a high voltage battery.
+
+    Neue Klasse cars never send `batteryManagement.header`, so looking for that
+    descriptor on its own misses them. They report `stateOfCharge.displayed`
+    instead, which is why both count. It lives here rather than in `utils` so
+    that module keeps its standalone import, which the fuzz harnesses rely on.
+    """
+    return DESC_SOC_HEADER in vehicle_state or DESC_SOC_DISPLAYED in vehicle_state

--- a/custom_components/cardata/lifecycle.py
+++ b/custom_components/cardata/lifecycle.py
@@ -57,7 +57,6 @@ from .const import (
     DEFAULT_TRIP_POLL_COOLDOWN_MINUTES,
     DESC_FUEL_LEVEL,
     DESC_REMAINING_FUEL,
-    DESC_SOC_HEADER,
     DIAGNOSTIC_LOG_INTERVAL,
     DOMAIN,
     MAGIC_SOC_DESCRIPTOR,
@@ -79,6 +78,7 @@ from .const import (
     OPTION_TRIP_POLL_COOLDOWN,
     SOC_LEARNING_STORAGE_KEY,
     SOC_LEARNING_STORAGE_VERSION,
+    has_hv_battery,
 )
 from .container import CardataContainerManager
 from .coordinator import CardataCoordinator
@@ -555,7 +555,7 @@ async def async_setup_cardata(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # and the sensor platform's ensure_entity callback is registered
         if coordinator.enable_magic_soc and coordinator._create_sensor_callback:
             for vin, vehicle_state in list(coordinator.data.items()):
-                has_battery = DESC_SOC_HEADER in vehicle_state
+                has_battery = has_hv_battery(vehicle_state)
                 has_fuel = DESC_REMAINING_FUEL in vehicle_state or DESC_FUEL_LEVEL in vehicle_state
                 is_phev = has_fuel and not coordinator._is_metadata_bev(vin)
                 if has_battery and not is_phev and MAGIC_SOC_DESCRIPTOR not in vehicle_state:

--- a/custom_components/cardata/number.py
+++ b/custom_components/cardata/number.py
@@ -41,10 +41,10 @@ from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import (
     DESC_REMAINING_FUEL,
-    DESC_SOC_HEADER,
     DOMAIN,
     MANUAL_CAPACITY_DESCRIPTOR,
     MANUAL_TANK_CAPACITY_DESCRIPTOR,
+    has_hv_battery,
 )
 from .utils import redact_vin
 
@@ -81,7 +81,7 @@ async def async_setup_entry(
         vehicle_name = coordinator.names.get(vin, redact_vin(vin))
 
         # Manual battery capacity for EV/PHEV vehicles
-        if DESC_SOC_HEADER in vehicle_data:
+        if has_hv_battery(vehicle_data):
             entities.append(
                 ManualBatteryCapacityNumber(
                     coordinator=coordinator,

--- a/custom_components/cardata/soc_wiring.py
+++ b/custom_components/cardata/soc_wiring.py
@@ -59,6 +59,7 @@ from .const import (
     MAGIC_SOC_DESCRIPTOR,
     PHASE_COUNT_LEAD_SECONDS,
     PREDICTED_SOC_DESCRIPTOR,
+    has_hv_battery,
 )
 from .descriptor_state import DescriptorState
 from .magic_soc import MagicSOCPredictor
@@ -1055,15 +1056,14 @@ def process_soc_descriptors(
                 anchor_soc_session(soc_predictor, magic_soc_pred, vin, vehicle_state, manual_cap)
 
     # Check if predicted_soc sensor should be created
-    if DESC_SOC_HEADER in vehicle_state or DESC_SOC_DISPLAYED in vehicle_state:
+    if has_hv_battery(vehicle_state):
         if PREDICTED_SOC_DESCRIPTOR not in vehicle_state:
             if pending.add_new_sensor(vin, PREDICTED_SOC_DESCRIPTOR):
                 schedule_debounce = True
 
     # Detect PHEV
-    has_hv_battery = DESC_SOC_HEADER in vehicle_state or DESC_SOC_DISPLAYED in vehicle_state
     has_fuel_system = DESC_REMAINING_FUEL in vehicle_state or DESC_FUEL_LEVEL in vehicle_state
-    if has_hv_battery:
+    if has_hv_battery(vehicle_state):
         is_phev = has_fuel_system and not coordinator._is_metadata_bev(vin)
         soc_predictor.set_vehicle_is_phev(vin, is_phev)
         magic_soc_pred.set_vehicle_is_phev(vin, is_phev)

--- a/tests/test_button_restore.py
+++ b/tests/test_button_restore.py
@@ -31,7 +31,12 @@ import pytest
 
 from custom_components.cardata import button as button_module
 from custom_components.cardata.button import LEARNING_RESET_KINDS, async_setup_entry
-from custom_components.cardata.const import DESC_SOC_HEADER, DOMAIN, MAGIC_SOC_DESCRIPTOR
+from custom_components.cardata.const import (
+    DESC_SOC_DISPLAYED,
+    DESC_SOC_HEADER,
+    DOMAIN,
+    MAGIC_SOC_DESCRIPTOR,
+)
 
 VIN = "WBA00000000000001"
 
@@ -83,8 +88,17 @@ class TestLearningResetRestore:
         data = {VIN: {DESC_SOC_HEADER: object()}}
         assert platform(rows, data) == {f"{VIN}_reset_ac_learning", f"{VIN}_reset_dc_learning"}
 
+    def test_a_neue_klasse_car_gets_them_on_a_first_install(self, platform):
+        """NK never sends the header, so displayed SOC has to be enough."""
+        data = {VIN: {DESC_SOC_DISPLAYED: object()}}
+        assert platform([], data) == {f"{VIN}_reset_ac_learning", f"{VIN}_reset_dc_learning"}
+
     def test_no_rows_and_no_battery_builds_nothing(self, platform):
         assert platform([]) == set()
+
+    def test_a_car_with_no_battery_descriptor_still_builds_nothing(self, platform):
+        data = {VIN: {"vehicle.travelledDistance": object()}}
+        assert platform([], data) == set()
 
 
 class TestConsumptionResetRestore:

--- a/tests/test_number_capacity.py
+++ b/tests/test_number_capacity.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2025, Renaud Allard <renaud@allard.it>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for which vehicles get the manual capacity number entities."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.cardata import number as number_module
+from custom_components.cardata.const import (
+    DESC_REMAINING_FUEL,
+    DESC_SOC_DISPLAYED,
+    DESC_SOC_HEADER,
+    DOMAIN,
+    MANUAL_CAPACITY_DESCRIPTOR,
+    MANUAL_TANK_CAPACITY_DESCRIPTOR,
+)
+from custom_components.cardata.number import async_setup_entry
+
+VIN = "WBA00000000000001"
+BATTERY_ID = f"{VIN}_{MANUAL_CAPACITY_DESCRIPTOR}"
+TANK_ID = f"{VIN}_{MANUAL_TANK_CAPACITY_DESCRIPTOR}"
+
+
+def registry_row(domain: str, unique_id: str) -> SimpleNamespace:
+    """The slice of an entity registry entry the platform reads."""
+    return SimpleNamespace(domain=domain, unique_id=unique_id, entity_id=f"{domain}.x")
+
+
+@pytest.fixture
+def platform(monkeypatch):
+    """Drive the number platform with a registry and a coordinator we control."""
+
+    def run(rows=(), coordinator_data=None):
+        coordinator = SimpleNamespace(
+            data=coordinator_data or {},
+            device_metadata={},
+            names={VIN: "iX3"},
+            _allowed_vins_initialized=False,
+            _allowed_vins=set(),
+        )
+        hass = SimpleNamespace(data={DOMAIN: {"entry": SimpleNamespace(coordinator=coordinator)}})
+        entry = SimpleNamespace(entry_id="entry")
+
+        added: list = []
+        monkeypatch.setattr(number_module, "async_get", lambda _hass: None)
+        monkeypatch.setattr(number_module, "async_entries_for_config_entry", lambda _reg, _entry_id: list(rows))
+
+        import asyncio
+
+        asyncio.run(async_setup_entry(hass, entry, added.extend))
+        return {entity._attr_unique_id for entity in added}
+
+    return run
+
+
+class TestManualBatteryCapacity:
+    """Which vehicles are offered the battery capacity override."""
+
+    def test_a_car_reporting_the_header_gets_it(self, platform):
+        assert platform(coordinator_data={VIN: {DESC_SOC_HEADER: object()}}) == {BATTERY_ID}
+
+    def test_a_neue_klasse_car_gets_it_on_a_first_install(self, platform):
+        """NK never sends the header, so displayed SOC has to be enough."""
+        assert platform(coordinator_data={VIN: {DESC_SOC_DISPLAYED: object()}}) == {BATTERY_ID}
+
+    def test_a_car_with_no_battery_does_not(self, platform):
+        assert platform(coordinator_data={VIN: {"vehicle.travelledDistance": object()}}) == set()
+
+    def test_it_comes_back_from_its_registry_row(self, platform):
+        """A restart skips bootstrap, so coordinator data is still empty."""
+        assert platform(rows=[registry_row("number", BATTERY_ID)]) == {BATTERY_ID}
+
+    def test_a_live_vehicle_is_not_built_twice(self, platform):
+        rows = [registry_row("number", BATTERY_ID)]
+        assert platform(rows, {VIN: {DESC_SOC_DISPLAYED: object()}}) == {BATTERY_ID}
+
+
+class TestManualTankCapacity:
+    """The fuel side is unchanged and still keyed on remaining fuel."""
+
+    def test_a_car_reporting_fuel_gets_it(self, platform):
+        assert platform(coordinator_data={VIN: {DESC_REMAINING_FUEL: object()}}) == {TANK_ID}
+
+    def test_a_phev_gets_both(self, platform):
+        data = {VIN: {DESC_SOC_DISPLAYED: object(), DESC_REMAINING_FUEL: object()}}
+        assert platform(coordinator_data=data) == {BATTERY_ID, TANK_ID}


### PR DESCRIPTION
`button.py` and `number.py` decide a vehicle has an HV battery from `batteryManagement.header` alone. BMW never sends that descriptor for Neue Klasse, so those cars get no Reset AC Learning button, no Reset DC Learning button and no Manual Battery Capacity input.

They do get the predicted SOC sensor, because `soc_wiring.py` accepts either the header or `stateOfCharge.displayed`, which is what covers NK. So the feature runs while its controls are missing, and a bad learned efficiency can be neither cleared from the UI nor worked around with a manual capacity.

Both platforms restore from the entity registry, but that only brings back entities created once already, so a fresh install never recovers.

### The helper

The test `soc_wiring.py` was already using is now `has_hv_battery` in `const.py`, next to the two descriptors it names and, like them, with no imports of its own. Both platforms call it.

It has to stay out of `utils.py`. Six fuzz harnesses put `custom_components/cardata` on `sys.path` and then do a bare `import utils`, so the module has to load without its package, and a relative import there raises `ImportError: attempted relative import with no known parent package`. `api_parsing`, `ratelimit`, `units` and `utils` are the four imported that way, and all four carry no relative imports today.

### The sibling site

`lifecycle.py` had the same header-only test when deciding which vehicles get a Magic SOC entity at startup. That one was not a permanent miss, since `soc_wiring.py` creates the entity on the next message with the correct test, but it delayed it. Both paths now agree.

`soc_wiring.py` also spelled the test out twice, once inline and once in a local named `has_hv_battery` that would have shadowed the import, so the local is gone and both places call the helper.

### Testing

`tests/test_number_capacity.py` is new and joins the CI list. It covers the header path, the displayed-only path, a car with no battery, registry restore, no double creation, and a PHEV getting both the battery and the tank control. `tests/test_button_restore.py` gains the NK case and a negative one. Both new cases were confirmed to fail against the old gate and pass with the helper.

The widened test only admits vehicles reporting the electric-namespaced displayed SOC. An ICE car with fuel data, a 48V state of health reading and a charging level on their own all still fall through.
